### PR TITLE
Make the plugin work in IntelliJ 2024.1 with the K2 Kotlin plugin mode enabled

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -17,4 +17,8 @@
         <projectService serviceImplementation="org.jetbrains.kotlin.test.helper.TestDataPathsConfiguration"/>
         <projectService serviceImplementation="org.jetbrains.kotlin.test.helper.actions.LastUsedTestService"/>
     </extensions>
+
+    <extensions defaultExtensionNs="org.jetbrains.kotlin">
+        <supportsKotlinK2Mode/>
+    </extensions>
 </idea-plugin>


### PR DESCRIPTION

All plugins that work with the K2 mode should explicitly mark it in their `plugin.xml`.

See https://youtrack.jetbrains.com/issue/KTIJ-24797 for details.