### PR TITLE
Implements `DumbAware` for actions to make them operable while indexing

### DIFF
--- a/src/org/jetbrains/kotlin/test/helper/KotlinTestDataFileEditorProvider.kt
+++ b/src/org/jetbrains/kotlin/test/helper/KotlinTestDataFileEditorProvider.kt
@@ -5,12 +5,13 @@ import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorPolicy
 import com.intellij.openapi.fileEditor.TextEditor
 import com.intellij.openapi.fileEditor.impl.text.TextEditorProvider
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.application
 import org.jetbrains.kotlin.test.helper.ui.TestDataEditor
 
-class KotlinTestDataFileEditorProvider: AsyncFileEditorProvider {
+class KotlinTestDataFileEditorProvider: AsyncFileEditorProvider, DumbAware {
     companion object {
         private val supportedExtensions = listOf("kt", "kts", "args")
     }

--- a/src/org/jetbrains/kotlin/test/helper/actions/ChooseAdditionalFileAction.kt
+++ b/src/org/jetbrains/kotlin/test/helper/actions/ChooseAdditionalFileAction.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup
 import com.intellij.openapi.actionSystem.Presentation
 import com.intellij.openapi.actionSystem.ex.ComboBoxAction
 import com.intellij.openapi.fileEditor.FileEditor
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.ui.ComboBox
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.ui.components.JBLabel
@@ -30,7 +31,7 @@ import javax.swing.JList
 class ChooseAdditionalFileAction(
     private val testDataEditor: TestDataEditor,
     private val previewEditorState: PreviewEditorState
-) : ComboBoxAction() {
+) : ComboBoxAction(), DumbAware {
     companion object {
         private const val NO_NAME_PROVIDED = "## no name provided ##"
     }
@@ -131,7 +132,7 @@ class ChooseAdditionalFileAction(
         "Show Diff",
         "Show diff between base and additional files",
         AllIcons.Actions.Diff
-    ) {
+    ), DumbAware {
         override fun actionPerformed(e: AnActionEvent) {
             val delegateAction = object : CompareFilesAction() {
                 override fun getDiffRequestChain(e: AnActionEvent): DiffRequestChain? {

--- a/src/org/jetbrains/kotlin/test/helper/actions/GeneratedTestComboBoxAction.kt
+++ b/src/org/jetbrains/kotlin/test/helper/actions/GeneratedTestComboBoxAction.kt
@@ -19,6 +19,7 @@ import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ProjectRootManager
 import com.intellij.openapi.ui.ComboBox
@@ -48,7 +49,7 @@ import javax.swing.Icon
 import javax.swing.JComponent
 import javax.swing.JList
 
-class GeneratedTestComboBoxAction(val baseEditor: TextEditor) : ComboBoxAction() {
+class GeneratedTestComboBoxAction(val baseEditor: TextEditor) : ComboBoxAction(), DumbAware {
     companion object {
         private val logger = Logger.getInstance(GeneratedTestComboBoxAction::class.java)
     }
@@ -182,7 +183,7 @@ class GeneratedTestComboBoxAction(val baseEditor: TextEditor) : ComboBoxAction()
                 val topLevelClass = testMethod.parentsOfType<PsiClass>().last()
 
                 val group: List<AnAction> = allActions.take(2).map {
-                    object : AnAction() {
+                    object : AnAction(), DumbAware {
                         override fun actionPerformed(e: AnActionEvent) {
                             val dataContext = SimpleDataContext.builder().apply {
                                 val newLocation = PsiLocation.fromPsiElement(identifier)
@@ -317,7 +318,7 @@ class GeneratedTestComboBoxAction(val baseEditor: TextEditor) : ComboBoxAction()
         }
     }
 
-    inner class RunAction(private val index: Int, text: String, icon: Icon) : AnAction(text, text, icon) {
+    inner class RunAction(private val index: Int, text: String, icon: Icon) : AnAction(text, text, icon), DumbAware {
         override fun actionPerformed(e: AnActionEvent) {
             state.executeRunConfigAction(e, index)
         }
@@ -334,8 +335,7 @@ class GeneratedTestComboBoxAction(val baseEditor: TextEditor) : ComboBoxAction()
     "Go To Test Method",
     "Go to test method declaration",
     AllIcons.Nodes.Method
-    ) {
-
+    ), DumbAware {
         var testMethods: List<PsiMethod> = emptyList()
 
         override fun actionPerformed(e: AnActionEvent) {
@@ -351,7 +351,7 @@ class GeneratedTestComboBoxAction(val baseEditor: TextEditor) : ComboBoxAction()
         "Run All...",
         "Run all tests via gradle",
         AllIcons.RunConfigurations.Junit
-    ) {
+    ), DumbAware {
         private var commandLine = ""
 
         fun computeTasksToRun(testMethods: List<PsiMethod>) {

--- a/src/org/jetbrains/kotlin/test/helper/ui/TestDataEditor.kt
+++ b/src/org/jetbrains/kotlin/test/helper/ui/TestDataEditor.kt
@@ -16,6 +16,7 @@ import com.intellij.openapi.fileEditor.FileEditorLocation
 import com.intellij.openapi.fileEditor.FileEditorState
 import com.intellij.openapi.fileEditor.FileEditorStateLevel
 import com.intellij.openapi.fileEditor.TextEditor
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.Pair
@@ -124,7 +125,7 @@ class TestDataEditor(
     private fun createTestRunToolbar(): ActionToolbar {
         val generatedTestComboBoxAction = GeneratedTestComboBoxAction(baseEditor)
 
-        val reloadGeneratedTestsAction = object : AnAction("Reload Tests", "Reload Tests", AllIcons.Actions.Refresh) {
+        val reloadGeneratedTestsAction = object : AnAction("Reload Tests", "Reload Tests", AllIcons.Actions.Refresh), DumbAware {
             override fun actionPerformed(e: AnActionEvent) {
                 generatedTestComboBoxAction.state.updateTestsList()
             }


### PR DESCRIPTION
It partially fixes #37

Also, add `DumbAware` to `KotlinTestDataFileEditorProvider`. Despite the fact it currently doesn't implement `PossiblyDumbAware` but it will be after switching to IntelliJ 2024