### PR TITLE
Introduce `testGlobally`

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -16,6 +16,11 @@
         <projectConfigurable bundle="messages.MyBundle" instance="org.jetbrains.kotlin.test.helper.TestDataPathsConfigurable"/>
         <projectService serviceImplementation="org.jetbrains.kotlin.test.helper.TestDataPathsConfiguration"/>
         <projectService serviceImplementation="org.jetbrains.kotlin.test.helper.actions.LastUsedTestService"/>
+
+        <!-- For some reason, doesn't work when put into `<extensions defaultExtensionNs="org.jetbrains.kotlin">`. -->
+        <!-- Also, `order="first"` is important somehow. -->
+        <runAnything.executionProvider implementation="org.jetbrains.kotlin.test.helper.runAnything.TestGloballyRunAnythingProvider"
+                                       order="first"/>
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">

--- a/src/org/jetbrains/kotlin/test/helper/runAnything/TestGloballyRunAnythingProvider.kt
+++ b/src/org/jetbrains/kotlin/test/helper/runAnything/TestGloballyRunAnythingProvider.kt
@@ -1,0 +1,211 @@
+package org.jetbrains.kotlin.test.helper.runAnything
+
+import com.intellij.ide.actions.runAnything.RunAnythingAction.EXECUTOR_KEY
+import com.intellij.ide.actions.runAnything.RunAnythingUtil
+import com.intellij.ide.actions.runAnything.activity.RunAnythingCommandLineProvider
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.plugins.gradle.action.GradleExecuteTaskAction
+import java.io.File
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.wm.WindowManager
+import java.awt.Component
+import javax.swing.JWindow
+
+private const val COMMAND = "testGlobally"
+private const val TESTS = "--tests"
+private val QUOTES = listOf('\'', '\"')
+
+class TestGloballyRunAnythingProvider : RunAnythingCommandLineProvider() {
+    /**
+     * Basically a map that transforms the input somehow.
+     * The plugin will only ever receive something coming through a successful mapping.
+     * Otherwise, we consider the input as not-ours and don't work with it.
+     */
+    override fun findMatchingValue(dataContext: DataContext, pattern: String): String? =
+        pattern.takeIf { COMMAND.startsWith(pattern) || pattern.startsWith(COMMAND) }
+
+    /**
+     * Some strange thing that is checked against the input command on whether one
+     * is a prefix of the other.
+     * See [execute] -> [RunAnythingCommandLineProvider.run] -> [RunAnythingCommandLineProvider.parseCommandLine].
+     */
+    override fun getHelpCommand(): String = COMMAND
+
+    /**
+     * Must be present for [suggestCompletionVariants] to be called.
+     */
+    override fun getCompletionGroupTitle(): String = "Global Test Runner"
+
+    override fun suggestCompletionVariants(dataContext: DataContext, commandLine: CommandLine): Sequence<String> {
+        return when {
+            !commandLine.isCorrectSoFar -> emptySequence()
+            commandLine.toComplete.suggests(TESTS) -> sequenceOf(TESTS)
+            commandLine.toComplete.isEmpty() && commandLine.completedParameters.lastOrNull() != TESTS -> {
+                sequenceOf(TESTS)
+            }
+            else -> sequenceOf()
+        }
+    }
+
+    private fun String.suggests(another: String): Boolean =
+        isNotEmpty() && another.startsWith(this) && another != this
+
+    private val List<String>.isCorrectParametersList: Boolean
+        get() = withIndex().all { (index, value) -> index.isOdd || value == TESTS }
+
+    private val CommandLine.isCorrectSoFar: Boolean
+        get() = completedParameters.isCorrectParametersList
+
+    private val CommandLine.isCorrectCompletely: Boolean
+        get() = parameters.isCorrectParametersList && parameters.size.isEven
+
+    private val Int.isEven get() = this and 1 == 0
+    private val Int.isOdd get() = !isEven
+
+    override fun run(dataContext: DataContext, commandLine: CommandLine): Boolean {
+        val project = RunAnythingUtil.fetchProject(dataContext)
+
+        if (!commandLine.isCorrectCompletely) {
+            return failure("This is not a valid `$COMMAND` call", project)
+        }
+
+        val workingDirectory = project.basePath
+            ?: return failure("Failed to get the project base path and set up the working directory", project)
+
+        val testFiltersFqNames = commandLine.parameters
+            .filterIndexed { index, _ -> index.isOdd }
+            .map { it.removeQuotesIfNeeded() }
+        val packagePathsToFilters = testFiltersFqNames.groupBy(::guessPackagePath)
+        val moduleToFilters = mapModulesToRelatedFilters(project, packagePathsToFilters)
+
+        val gradleCommand = listOf("--continue") + moduleToFilters.entries.flatMap { (module, filters) ->
+            listOf(module.gradleSubprojectPath + ":test") + filters.flatMap { listOf(TESTS, it) }
+        }
+
+        val executor = EXECUTOR_KEY.getData(dataContext)
+        GradleExecuteTaskAction.runGradle(project, executor, workingDirectory, gradleCommand.joinToString(" "))
+        return true
+    }
+
+    private fun mapModulesToRelatedFilters(
+        project: Project,
+        packagePathsToFilters: Map<String, List<String>>,
+    ): MutableMap<Module, MutableSet<String>> {
+        val packagePrefixes = packagePathsToFilters.keys.flatMapTo(mutableSetOf(), ::getAllPrefixes)
+        val moduleToFilters = mutableMapOf<Module, MutableSet<String>>()
+
+        fun traverseDirectory(directory: VirtualFile, project: Module, pathSoFar: String) {
+            if (packagePrefixes.none { it.startsWith(pathSoFar) }) {
+                return
+            }
+
+            val affectedFilters = packagePathsToFilters.entries
+                .filter { (path, _) -> path == pathSoFar }
+                .flatMap { (_, filters) -> filters }
+
+            if (affectedFilters.isNotEmpty()) {
+                moduleToFilters.getOrPut(project) { mutableSetOf() } += affectedFilters
+            }
+
+            for (it in directory.subdirectories) {
+                traverseDirectory(it, project, "$pathSoFar/" + it.name)
+            }
+        }
+
+        val manager = ModuleManager.getInstance(project)
+        val modules = manager.modules
+
+        modules.forEach { module ->
+            val moduleRootManager = ModuleRootManager.getInstance(module)
+            val testSources = moduleRootManager.sourceRoots
+                .filter { moduleRootManager.fileIndex.isInTestSourceContent(it) }
+
+            for (source in testSources) {
+                traverseDirectory(source, module, pathSoFar = "")
+            }
+        }
+
+        return moduleToFilters
+    }
+
+    /**
+     * Returns `:path:to:module`
+     */
+    private val Module.gradleSubprojectPath: String
+        // In kotlin.git, source roots don't reside in the module directly,
+        // but rather in either the `main` or `test` submodules.
+        // Note that `tests-gen` roots reside in `test` submodules.
+        get() = ":" + name.removePrefix("kotlin.")
+            .removeSuffix(".tests")
+            .removeSuffix(".test")
+            .replace(".", ":")
+
+    private val VirtualFile.subdirectories get() = children.filter { it.isDirectory }
+
+    private operator fun File.div(name: String) = File(absolutePath + File.separator + name)
+
+    /**
+     * Tries to get a package name from a filter value.
+     * Assumes that the filter starts with a full package name containing no wildcards.
+     *
+     * Examples:
+     * - `"a.b.C.d"` -> `"/a/b"`
+     * - `"a.b"` -> `"/a/b"`
+     * - `"C.d"` -> ``
+     */
+    private fun guessPackagePath(filter: String): String = filter
+        .split(".")
+        .takeWhile { it.matches("""[a-z]\w*""".toRegex()) }
+        .let { listOf("") + it }
+        .joinToString("/")
+
+    /**
+     * `"/a/b/c"` -> `["/a/b/c", "/a/b", "/a", ""]`
+     */
+    private fun getAllPrefixes(path: String): List<String> {
+        var current = path
+        val prefixes = mutableListOf(current)
+        var lastDot = current.lastIndexOf('/')
+
+        while (lastDot != -1) {
+            current = current.substring(0, lastDot)
+            lastDot = current.lastIndexOf('/')
+            prefixes += current
+        }
+
+        return prefixes
+    }
+
+    private fun String.removeQuotesIfNeeded(): String {
+        val firstIndex = if (firstOrNull() in QUOTES) 1 else 0
+        val lastIndex = if (lastOrNull() in QUOTES) lastIndex else length
+
+        return when {
+            firstIndex != 0 || lastIndex != length -> substring(firstIndex, lastIndex)
+            else -> this
+        }
+    }
+
+    private fun failure(error: String, project: Project) = false.also {
+        // There's a bug that the error dialog is partially covered with the
+        // Run Anything window, so you can't see it.
+        // Let's try closing it eagerly.
+        WindowManager.getInstance().getFocusedComponent(project)?.parentOfType<JWindow>()?.dispose()
+        Messages.showErrorDialog(error, "Could Not Run Command")
+    }
+
+    private inline fun <reified C> Component.parentOfType(): C? {
+        var result = parent
+
+        while (result !is C && result != null) {
+            result = result.parent
+        }
+
+        return result as? C
+    }
+}


### PR DESCRIPTION
This command allows tests across the whole project given the inclusion test filters. There's a limitation, though: the packages must fully be specified and must not contain wildcards.

This change accompanies the `GetAllTests()` script from Hacky Helpers that can prepare a `testGlobally` call from a TeamCity failed build tab which will only include the failed tests.

The syntax is: `testGlobally --tests 'a.b.Test$Sub.testSomething' --tests a.b.* ...`.

Note that specifying a filter without a package (`--tests SomeTestGenerated`) will result in all modules with test source sets being called via `:test`. The algorithm searches for the relevant module by whether comparing the package with the directory structure, and empty package represents the source set root which is always present for every source set.