### PR TITLE
Adapt to the new K2 Kotlin Plugin compatibility marker after KTIJ-30474

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -25,5 +25,6 @@
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">
         <supportsKotlinK2Mode/>
+        <supportsKotlinPluginMode supportsK2="true" supportsK1="true"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
The old one is left intact to avoid breaking compatibility with older versions of IntelliJ IDEA

https://youtrack.jetbrains.com/issue/KTIJ-30474