### PR TITLE
Remove CopyTextWithoutMetadataAction from the regular copy-paste group

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -56,7 +56,6 @@
                 class="org.jetbrains.kotlin.test.helper.actions.CopyTextWithoutMetadataAction"
                 text="Copy Without Metadata"
                 description="Copies the selected text in the current editor without Kotlin testdata metadata">
-            <add-to-group group-id="CutCopyPasteGroup" anchor="last" />
             <add-to-group group-id="Copy.Paste.Special" anchor="last" />
         </action>
 


### PR DESCRIPTION
@cypressious Let's leave the new copy text action only in the editor context menu. Currently, it's shown in the project view, but it's useless there.

<img width="414" alt="Screenshot 2025-02-20 at 13 42 43" src="https://github.com/user-attachments/assets/b14fdc30-a05a-497e-8d6b-2a8091847060" />
