### PR TITLE
[minor] Update the extension for test data with IDE-freezing potential

### DIFF
--- a/src/org/jetbrains/kotlin/test/helper/utils.kt
+++ b/src/org/jetbrains/kotlin/test/helper/utils.kt
@@ -74,7 +74,7 @@ fun glob(searchPattern: String, run: (Path) -> Unit) {
     )
 }
 
-private val supportedExtensions = listOf("kt", "kts", "args", "nkt")
+private val supportedExtensions = listOf("kt", "kts", "args", "can-freeze-ide")
 
 enum class TestDataType {
     File,


### PR DESCRIPTION
should be merged when `kotlin.git:rr/ruban/can-freeze-ide-test-data` is merged to `kotlin.git:master`