### PR TITLE
Add file separator and folding support for multifile test data files

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -50,6 +50,15 @@
 
         <executor implementation="org.jetbrains.kotlin.test.helper.executor.RunAndApplyDiffsExecutor"/>
         <programRunner implementation="org.jetbrains.kotlin.test.helper.executor.RunAndApplyDiffsProgramRunner"/>
+
+        <codeInsight.lineMarkerProvider
+                implementationClass="org.jetbrains.kotlin.test.helper.codeinsight.MultifileTestDataLineMarkerProvider"
+                language=""/>
+
+        <lang.foldingBuilder
+                implementationClass="org.jetbrains.kotlin.test.helper.codeinsight.MultifileTestDataFoldingBuilder"
+                language=""/>
+
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -59,6 +59,14 @@
                 implementationClass="org.jetbrains.kotlin.test.helper.codeinsight.MultifileTestDataFoldingBuilder"
                 language=""/>
 
+        <fileType name="MultifileTestData" implementationClass="org.jetbrains.kotlin.test.helper.lang.MultifileTestDataFileType"
+                  fieldName="INSTANCE" language="multifileTestData"/>
+
+        <lang.parserDefinition language="multifileTestData" implementationClass="org.jetbrains.kotlin.test.helper.lang.MultifileTestDataParserDefinition" />
+
+        <fileTypeOverrider implementation="org.jetbrains.kotlin.test.helper.codeinsight.MultifileTestDataFileTypeOverrider"/>
+
+        <multiHostInjector implementation="org.jetbrains.kotlin.test.helper.codeinsight.MultifileTestDataMultiHostInjector"/>
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">

--- a/resources/icons/multifile_testdata.svg
+++ b/resources/icons/multifile_testdata.svg
@@ -1,0 +1,27 @@
+<!-- Copyright 2000-2026 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <mask id="cutout-mask">
+            <rect width="16" height="16" fill="white"/>
+            <g stroke="black" stroke-width="3" stroke-linejoin="round" stroke-linecap="round">
+                <path d="M10 10H14.6445L12.6748 11.9697C12.3819 12.2626 12.3819 12.7374 12.6748 13.0303L14.6445 15H10V10Z"
+                      fill="black" stroke="black"/>
+                <path d="M9 10C9 9.44771 9.44772 9 10 9H15.248C15.9162 9 16.2508 9.80786 15.7783 10.2803L13.5587 12.5L15.7783 14.7197C16.2508 15.1921 15.9162 16 15.248 16H10C9.44772 16 9 15.5523 9 15V10ZM14.6445 10L10 10V15H14.6445L12.6748 13.0303C12.3819 12.7374 12.3819 12.2626 12.6748 11.9697L14.6445 10Z"
+                      fill="black" stroke="black"/>
+            </g>
+        </mask>
+    </defs>
+    <g mask="url(#cutout-mask)">
+        <rect x="2.5" y="2.5" width="11" height="11" rx="1.5" fill="#E7EFFD" stroke="#3574F0"/>
+        <rect x="5" y="4" width="6" height="2" rx="0.5" fill="#3574F0"/>
+        <rect x="5" y="7" width="6" height="2" rx="0.5" fill="#3574F0"/>
+        <rect x="5" y="10" width="6" height="2" rx="0.5" fill="#3574F0"/>
+    </g>
+    <g>
+        <path d="M10 10H14.6445L12.6748 11.9697C12.3819 12.2626 12.3819 12.7374 12.6748 13.0303L14.6445 15H10V10Z"
+              fill="#FAF5FF"/>
+        <path fill-rule="evenodd" clip-rule="evenodd"
+              d="M9 10C9 9.44771 9.44772 9 10 9H15.248C15.9162 9 16.2508 9.80786 15.7783 10.2803L13.5587 12.5L15.7783 14.7197C16.2508 15.1921 15.9162 16 15.248 16H10C9.44772 16 9 15.5523 9 15V10ZM14.6445 10L10 10V15H14.6445L12.6748 13.0303C12.3819 12.7374 12.3819 12.2626 12.6748 11.9697L14.6445 10Z"
+              fill="#834DF0"/>
+    </g>
+</svg>

--- a/resources/messages/MyBundle.properties
+++ b/resources/messages/MyBundle.properties
@@ -24,3 +24,5 @@ action.GitResetMasterToGreenCommitAction.text=Reset 'master' to the Latest Green
 action.GitResetMasterToGreenCommitAction.description=Resets the 'master' branch state to the latest successfully built commit according to TeamCity. Doesn't affect or change the current branch.
 action.GitRebaseOnGreenMasterCommitAction.text=Rebase {0} onto the Latest Green ''master''
 action.GitRebaseOnGreenMasterCommitAction.description=Rebases the current branch on the latest successfully built commit in the 'master' branch, according to TeamCity.
+
+code.insight.file.marker.separator.provider.name=Kotlin Compiler Devkit line markers

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataFileTypeOverrider.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataFileTypeOverrider.kt
@@ -1,0 +1,18 @@
+package org.jetbrains.kotlin.test.helper.codeinsight
+
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.fileTypes.impl.FileTypeOverrider
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.vfs.VirtualFile
+import org.jetbrains.kotlin.test.helper.getTestDataType
+import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataFileType
+
+class MultifileTestDataFileTypeOverrider: FileTypeOverrider, DumbAware {
+    override fun getOverriddenFileType(file: VirtualFile): FileType? =
+        MultifileTestDataFileType.takeIf {
+            ProjectManager.getInstance().openProjects.any {
+                file.getTestDataType(it) != null
+            }
+        }
+}

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataFoldingBuilder.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataFoldingBuilder.kt
@@ -48,7 +48,9 @@ internal class MultifileTestDataFoldingBuilder: CustomFoldingBuilder(), DumbAwar
             previousDirective = directive
         }
 
-        addDescriptor(text.length, previousDirective)
+        previousDirective?.let {
+            addDescriptor(text.length, it)
+        }
     }
 
     override fun getLanguagePlaceholderText(node: ASTNode, range: TextRange): String =

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataFoldingBuilder.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataFoldingBuilder.kt
@@ -1,0 +1,59 @@
+package org.jetbrains.kotlin.test.helper.codeinsight
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.folding.CustomFoldingBuilder
+import com.intellij.lang.folding.FoldingDescriptor
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+
+internal class MultifileTestDataFoldingBuilder: CustomFoldingBuilder(), DumbAware {
+
+    override fun isCustomFoldingCandidate(node: ASTNode): Boolean {
+        if (node.psi.containingFile?.multiTestDataFile == null) return false
+
+        return MODULE_FILE_PATTERN.matcher(node.text).find()
+    }
+
+    override fun buildLanguageFoldRegions(
+        descriptors: MutableList<FoldingDescriptor>,
+        root: PsiElement,
+        document: Document,
+        quick: Boolean,
+    ) {
+        val file = (root as? PsiFile)?.multiTestDataFile ?: return
+        val text = file.text
+        val matcher = MODULE_FILE_PATTERN.matcher(text)
+
+        var previousDirective: String? = null
+        var previousStart: Int? = null
+
+        fun addDescriptor(end: Int, name: String?) {
+            val textRange = TextRange(previousStart ?: 0, end)
+            val descriptor = FoldingDescriptor(root, textRange)
+            descriptor.placeholderText = name + Typography.ellipsis.toString()
+            descriptors += descriptor
+        }
+
+        while (matcher.find()) {
+            val start = matcher.start()
+            val directive = matcher.group(0).trim()
+
+            if (previousStart != null) {
+                addDescriptor(start - 1, previousDirective)
+            }
+            previousStart = start
+            previousDirective = directive
+        }
+
+        addDescriptor(text.length, previousDirective)
+    }
+
+    override fun getLanguagePlaceholderText(node: ASTNode, range: TextRange): String =
+        Typography.ellipsis.toString()
+
+    override fun isRegionCollapsedByDefault(node: ASTNode): Boolean = false
+
+}

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataFoldingBuilder.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataFoldingBuilder.kt
@@ -7,14 +7,13 @@ import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataEntry
+import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataTextFileImpl
 
 internal class MultifileTestDataFoldingBuilder: CustomFoldingBuilder(), DumbAware {
 
     override fun isCustomFoldingCandidate(node: ASTNode): Boolean {
-        if (node.psi.containingFile?.multiTestDataFile == null) return false
-
-        return MODULE_FILE_PATTERN.matcher(node.text).find()
+        return node.psi is MultifileTestDataEntry
     }
 
     override fun buildLanguageFoldRegions(
@@ -23,33 +22,29 @@ internal class MultifileTestDataFoldingBuilder: CustomFoldingBuilder(), DumbAwar
         document: Document,
         quick: Boolean,
     ) {
-        val file = (root as? PsiFile)?.multiTestDataFile ?: return
-        val text = file.text
-        val matcher = MODULE_FILE_PATTERN.matcher(text)
+        val file = root as? MultifileTestDataTextFileImpl ?: return
 
-        var previousDirective: String? = null
-        var previousStart: Int? = null
+        for (entry in file.entries) {
+            val content = entry.content
+            if (content?.textContains('\n') != true) continue
 
-        fun addDescriptor(end: Int, name: String?) {
-            val textRange = TextRange(previousStart ?: 0, end)
-            val descriptor = FoldingDescriptor(root, textRange)
-            descriptor.placeholderText = name + Typography.ellipsis.toString()
-            descriptors += descriptor
-        }
+            val entityRange = entry.textRange
+            val range = TextRange(entityRange.startOffset, entityRange.endOffset - 1)
+            descriptors +=
+                FoldingDescriptor(entry.node, range).apply {
+                    placeholderText = entry.placeholderText + " " + Typography.ellipsis
+                }
 
-        while (matcher.find()) {
-            val start = matcher.start()
-            val directive = matcher.group(0).trim()
-
-            if (previousStart != null) {
-                addDescriptor(start - 1, previousDirective)
+            if (entry.moduleHeader != null) {
+                val fileHeader = entry.fileHeader
+                if (fileHeader != null) {
+                    val textRange = fileHeader.textRange
+                    descriptors +=
+                        FoldingDescriptor(fileHeader.node, TextRange(textRange.startOffset, range.endOffset)).apply {
+                            placeholderText = fileHeader.placeholderText + " " + Typography.ellipsis
+                        }
+                }
             }
-            previousStart = start
-            previousDirective = directive
-        }
-
-        previousDirective?.let {
-            addDescriptor(text.length, it)
         }
     }
 

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataLineMarkerProvider.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataLineMarkerProvider.kt
@@ -1,0 +1,49 @@
+package org.jetbrains.kotlin.test.helper.codeinsight
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzerSettings
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.openapi.editor.colors.CodeInsightColors
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.markup.SeparatorPlacement
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import org.jetbrains.kotlin.test.helper.getTestDataType
+import java.util.regex.Pattern
+
+/**
+ * Multifile test data file describes several files in a single `.test` data file,
+ * where files are separated by `// FILE: filename` directive.
+ */
+internal class MultifileTestDataLineMarkerProvider: LineMarkerProvider, DumbAware {
+
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? = null
+
+    override fun collectSlowLineMarkers(elements: List<PsiElement>, result: MutableCollection<in LineMarkerInfo<*>>) {
+        if (!DaemonCodeAnalyzerSettings.getInstance().SHOW_METHOD_SEPARATORS) return
+
+        val file = elements.firstOrNull()?.multiTestDataFile ?: return
+
+        val matcher = MODULE_FILE_PATTERN.matcher(file.text)
+        val globalScheme = EditorColorsManager.getInstance().globalScheme
+
+        while (matcher.find()) {
+            val start = matcher.start()
+            val end = matcher.end()
+
+            val info = LineMarkerInfo(file, TextRange(start, end))
+            info.separatorColor = globalScheme.getColor(CodeInsightColors.METHOD_SEPARATORS_COLOR)
+            info.separatorPlacement = SeparatorPlacement.TOP
+
+            result.add(info)
+        }
+
+    }
+}
+
+internal val MODULE_FILE_PATTERN = Pattern.compile("(//\\s*MODULE:\\s*(.*)\\R)?//\\s*FILE:\\s*(.*)\\R")
+
+internal val PsiElement.multiTestDataFile: PsiFile?
+    get() = containingFile?.takeIf { it.virtualFile.getTestDataType(project) != null }

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataLineMarkerProvider.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataLineMarkerProvider.kt
@@ -1,17 +1,11 @@
 package org.jetbrains.kotlin.test.helper.codeinsight
 
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzerSettings
-import com.intellij.codeInsight.daemon.LineMarkerInfo
-import com.intellij.codeInsight.daemon.LineMarkerProvider
-import com.intellij.openapi.editor.colors.CodeInsightColors
-import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.codeInsight.daemon.*
+import com.intellij.openapi.editor.colors.*
 import com.intellij.openapi.editor.markup.SeparatorPlacement
 import com.intellij.openapi.project.DumbAware
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
-import org.jetbrains.kotlin.test.helper.getTestDataType
-import java.util.regex.Pattern
+import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataEntry
 
 /**
  * Multifile test data file describes several files in a single `.test` data file,
@@ -19,31 +13,15 @@ import java.util.regex.Pattern
  */
 internal class MultifileTestDataLineMarkerProvider: LineMarkerProvider, DumbAware {
 
-    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? = null
+    override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
+        val entry = element as? MultifileTestDataEntry ?: return null
+        if (!DaemonCodeAnalyzerSettings.getInstance().SHOW_METHOD_SEPARATORS) return null
 
-    override fun collectSlowLineMarkers(elements: List<PsiElement>, result: MutableCollection<in LineMarkerInfo<*>>) {
-        if (!DaemonCodeAnalyzerSettings.getInstance().SHOW_METHOD_SEPARATORS) return
-
-        val file = elements.firstOrNull()?.multiTestDataFile ?: return
-
-        val matcher = MODULE_FILE_PATTERN.matcher(file.text)
         val globalScheme = EditorColorsManager.getInstance().globalScheme
-
-        while (matcher.find()) {
-            val start = matcher.start()
-            val end = matcher.end()
-
-            val info = LineMarkerInfo(file, TextRange(start, end))
-            info.separatorColor = globalScheme.getColor(CodeInsightColors.METHOD_SEPARATORS_COLOR)
-            info.separatorPlacement = SeparatorPlacement.TOP
-
-            result.add(info)
+        val anchor = entry.moduleHeader ?: entry.fileHeader ?: return null
+        return LineMarkerInfo(anchor, anchor.textRange).apply {
+            separatorPlacement = SeparatorPlacement.TOP
+            separatorColor = globalScheme.getColor(CodeInsightColors.METHOD_SEPARATORS_COLOR)
         }
-
     }
 }
-
-internal val MODULE_FILE_PATTERN = Pattern.compile("(//\\s*MODULE:\\s*(.*)\\R)?//\\s*FILE:\\s*(.*)\\R")
-
-internal val PsiElement.multiTestDataFile: PsiFile?
-    get() = containingFile?.takeIf { it.virtualFile.getTestDataType(project) != null }

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataMultiHostInjector.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataMultiHostInjector.kt
@@ -1,18 +1,20 @@
 package org.jetbrains.kotlin.test.helper.codeinsight
 
 import com.intellij.lang.Language
-import com.intellij.lang.injection.MultiHostInjector
-import com.intellij.lang.injection.MultiHostRegistrar
+import com.intellij.lang.injection.*
 import com.intellij.lang.java.JavaLanguage
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLanguageInjectionHost
 import org.jetbrains.annotations.Unmodifiable
 import org.jetbrains.kotlin.idea.KotlinLanguage
-import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataFileContent
+import org.jetbrains.kotlin.test.helper.lang.*
+import java.util.regex.Pattern
 
 class MultifileTestDataMultiHostInjector: MultiHostInjector {
+    private val pattern = Pattern.compile("(//.*)\\R")
     private val supportedElementTypes: List<Class<out PsiElement>> =
-        listOf(MultifileTestDataFileContent::class.java)
+        listOf(MultifileTestDataFileContent::class.java, MultifileTestDataPreamble::class.java)
 
     private val ignoredLanguagesForInjection: Set<Language> =
         setOf(KotlinLanguage.INSTANCE, JavaLanguage.INSTANCE)
@@ -21,14 +23,37 @@ class MultifileTestDataMultiHostInjector: MultiHostInjector {
         registrar: MultiHostRegistrar,
         context: PsiElement
     ) {
+        if (context is MultifileTestDataPreamble) {
+            injectCommentsAsKotlin(registrar, context)
+            return
+        }
+
         val content =
             (context as? MultifileTestDataFileContent)?.takeIf { it.textLength != 0 } ?: return
         val language = content.entry?.fileHeader?.injectedLanguage ?: return
-        if (language in ignoredLanguagesForInjection) return
+
+        if (language in ignoredLanguagesForInjection) {
+            injectCommentsAsKotlin(registrar, context)
+            return
+        }
 
         registrar.startInjecting(language)
         registrar.addPlace(null, null, content, TextRange(0, content.textLength))
         registrar.doneInjecting()
+    }
+
+    private fun injectCommentsAsKotlin(
+        registrar: MultiHostRegistrar,
+        context: PsiLanguageInjectionHost
+    ) {
+        val fileContent = context.text ?: return
+        val matcher = pattern.matcher(fileContent)
+        while (matcher.find()) {
+            registrar.startInjecting(KotlinLanguage.INSTANCE)
+            val textRange = TextRange(matcher.start(1), matcher.end(1))
+            registrar.addPlace(null, null, context, textRange)
+            registrar.doneInjecting()
+        }
     }
 
     override fun elementsToInjectIn(): @Unmodifiable List<Class<out PsiElement>> =

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataMultiHostInjector.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataMultiHostInjector.kt
@@ -1,0 +1,36 @@
+package org.jetbrains.kotlin.test.helper.codeinsight
+
+import com.intellij.lang.Language
+import com.intellij.lang.injection.MultiHostInjector
+import com.intellij.lang.injection.MultiHostRegistrar
+import com.intellij.lang.java.JavaLanguage
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import org.jetbrains.annotations.Unmodifiable
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataFileContent
+
+class MultifileTestDataMultiHostInjector: MultiHostInjector {
+    private val supportedElementTypes: List<Class<out PsiElement>> =
+        listOf(MultifileTestDataFileContent::class.java)
+
+    private val ignoredLanguagesForInjection: Set<Language> =
+        setOf(KotlinLanguage.INSTANCE, JavaLanguage.INSTANCE)
+
+    override fun getLanguagesToInject(
+        registrar: MultiHostRegistrar,
+        context: PsiElement
+    ) {
+        val content =
+            (context as? MultifileTestDataFileContent)?.takeIf { it.textLength != 0 } ?: return
+        val language = content.entry?.fileHeader?.injectedLanguage ?: return
+        if (language in ignoredLanguagesForInjection) return
+
+        registrar.startInjecting(language)
+        registrar.addPlace(null, null, content, TextRange(0, content.textLength))
+        registrar.doneInjecting()
+    }
+
+    override fun elementsToInjectIn(): @Unmodifiable List<Class<out PsiElement>> =
+        supportedElementTypes
+}

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataElementTypes.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataElementTypes.kt
@@ -1,0 +1,26 @@
+package org.jetbrains.kotlin.test.helper.lang
+
+import com.intellij.psi.TokenType
+import com.intellij.psi.tree.IElementType
+import com.intellij.psi.tree.IFileElementType
+import com.intellij.psi.tree.TokenSet
+
+internal class MultifileTestDataTokenType(debugName: String) : IElementType(debugName, MultifileTestDataLanguage)
+
+internal class MultifileTestDataElementType(debugName: String) : IElementType(debugName, MultifileTestDataLanguage)
+
+internal val MULTIFILE_TEXT_FILE: IFileElementType = IFileElementType(MultifileTestDataLanguage)
+
+internal val MULTIFILE_PREAMBLE_TEXT = MultifileTestDataTokenType("MULTIFILE_PREAMBLE_TEXT")
+internal val MULTIFILE_MODULE_LINE = MultifileTestDataTokenType("MULTIFILE_MODULE_LINE")
+internal val MULTIFILE_FILE_LINE = MultifileTestDataTokenType("MULTIFILE_FILE_LINE")
+internal val MULTIFILE_CONTENT_TEXT = MultifileTestDataTokenType("MULTIFILE_CONTENT_TEXT")
+
+internal val MULTIFILE_PREAMBLE = MultifileTestDataElementType("MULTIFILE_PREAMBLE")
+internal val MULTIFILE_ENTRY = MultifileTestDataElementType("MULTIFILE_ENTRY")
+internal val MULTIFILE_MODULE_HEADER = MultifileTestDataElementType("MULTIFILE_MODULE_HEADER")
+internal val MULTIFILE_FILE_HEADER = MultifileTestDataElementType("MULTIFILE_FILE_HEADER")
+internal val MULTIFILE_FILE_CONTENT = MultifileTestDataElementType("MULTIFILE_FILE_CONTENT")
+
+internal val MULTIFILE_WHITE_SPACES: TokenSet = TokenSet.create(TokenType.WHITE_SPACE)
+internal val MULTIFILE_COMMENT_TOKENS: TokenSet = TokenSet.EMPTY

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLanguage.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLanguage.kt
@@ -1,0 +1,19 @@
+package org.jetbrains.kotlin.test.helper.lang
+
+import com.intellij.lang.Language
+import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.util.IconLoader
+import org.jetbrains.kotlin.idea.KotlinLanguage
+import javax.swing.Icon
+
+object MultifileTestDataFileType : LanguageFileType(MultifileTestDataLanguage) {
+    private val _icon: Icon = IconLoader.getIcon("/icons/multifile_testdata.svg", MultifileTestDataFileType::class.java)
+    override fun getIcon(): Icon = _icon
+    override fun getName(): String = "MultifileTestData"
+    override fun getDescription(): String = "Multifile test data file"
+    override fun getDefaultExtension(): String = "test"
+}
+
+object MultifileTestDataLanguage : Language(KotlinLanguage.INSTANCE, "multifileTestData") {
+    private fun readResolve(): Any = MultifileTestDataLanguage
+}

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexer.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexer.kt
@@ -1,0 +1,205 @@
+package org.jetbrains.kotlin.test.helper.lang
+
+import com.intellij.lexer.LexerBase
+import com.intellij.psi.TokenType
+import com.intellij.psi.tree.IElementType
+
+class MultifileTestDataLexer : LexerBase() {
+    private var buffer: CharSequence = ""
+    private var endOffset: Int = 0
+    private var state: Int = BEFORE_FIRST_ENTRY
+
+    private var tokenStart: Int = 0
+    private var tokenEnd: Int = 0
+    private var tokenType: IElementType? = null
+
+    override fun start(
+        buffer: CharSequence,
+        startOffset: Int,
+        endOffset: Int,
+        initialState: Int,
+    ) {
+        this.buffer = buffer
+        this.endOffset = endOffset
+        state = initialState
+        tokenStart = startOffset
+        locateToken()
+    }
+
+    override fun getState(): Int = state
+
+    override fun getTokenType(): IElementType? = tokenType
+
+    override fun getTokenStart(): Int = tokenStart
+
+    override fun getTokenEnd(): Int = tokenEnd
+
+    override fun advance() {
+        tokenStart = tokenEnd
+        locateToken()
+    }
+
+    override fun getBufferSequence(): CharSequence = buffer
+
+    override fun getBufferEnd(): Int = endOffset
+
+    private fun locateToken() {
+        if (tokenStart >= endOffset) {
+            tokenType = null
+            tokenEnd = endOffset
+            return
+        }
+
+        when (state) {
+            BEFORE_FIRST_ENTRY -> locateBeforeFirstEntry()
+            AFTER_MODULE_HEADER -> locateAfterModuleHeader()
+            AFTER_FILE_HEADER -> locateAfterFileHeader()
+            else -> error("Unexpected state: $state")
+        }
+    }
+
+    private fun locateBeforeFirstEntry() {
+        when {
+            isStructuralModuleHeaderAt(tokenStart) -> setToken(MULTIFILE_MODULE_LINE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
+            isFileHeaderAt(tokenStart) -> setToken(MULTIFILE_FILE_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
+            else -> {
+                tokenType = MULTIFILE_PREAMBLE_TEXT
+                tokenEnd = nextBoundaryOffset(tokenStart)
+                state = BEFORE_FIRST_ENTRY
+            }
+        }
+    }
+
+    private fun locateAfterModuleHeader() {
+        when {
+            isWhitespaceLine(tokenStart) -> setToken(TokenType.WHITE_SPACE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
+            isFileHeaderAt(tokenStart) -> setToken(MULTIFILE_FILE_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
+            else -> {
+                tokenType = MULTIFILE_CONTENT_TEXT
+                tokenEnd = nextBoundaryOffset(tokenStart)
+                state = AFTER_FILE_HEADER
+            }
+        }
+    }
+
+    private fun locateAfterFileHeader() {
+        when {
+            isStructuralModuleHeaderAt(tokenStart) -> setToken(MULTIFILE_MODULE_LINE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
+            isFileHeaderAt(tokenStart) -> setToken(MULTIFILE_FILE_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
+            else -> {
+                tokenType = MULTIFILE_CONTENT_TEXT
+                tokenEnd = nextBoundaryOffset(tokenStart)
+                state = AFTER_FILE_HEADER
+            }
+        }
+    }
+
+    private fun setToken(
+        type: IElementType,
+        end: Int,
+        newState: Int,
+    ) {
+        tokenType = type
+        tokenEnd = end
+        state = newState
+    }
+
+    private fun nextBoundaryOffset(offset: Int): Int {
+        var cursor = offset
+        while (cursor < endOffset) {
+            if (isFileHeaderAt(cursor) || isStructuralModuleHeaderAt(cursor)) {
+                return cursor
+            }
+            cursor = lineEnd(cursor)
+        }
+        return endOffset
+    }
+
+    private fun isStructuralModuleHeaderAt(offset: Int): Boolean {
+        if (!isDirectiveLine(offset, "MODULE")) {
+            return false
+        }
+
+        var nextOffset = lineEnd(offset)
+        while (nextOffset < endOffset && isWhitespaceLine(nextOffset)) {
+            nextOffset = lineEnd(nextOffset)
+        }
+
+        return nextOffset < endOffset && isFileHeaderAt(nextOffset)
+    }
+
+    private fun isFileHeaderAt(offset: Int): Boolean = isDirectiveLine(offset, "FILE")
+
+    private fun isDirectiveLine(
+        offset: Int,
+        directiveName: String,
+    ): Boolean {
+        if (offset >= endOffset || buffer[offset] != '/' || offset + 1 >= endOffset || buffer[offset + 1] != '/') {
+            return false
+        }
+
+        var cursor = offset + 2
+        while (cursor < endOffset && (buffer[cursor] == ' ' || buffer[cursor] == '\t')) {
+            cursor++
+        }
+
+        val directivePrefix = "$directiveName:"
+        if (cursor + directivePrefix.length > endOffset) {
+            return false
+        }
+
+        for (index in directivePrefix.indices) {
+            if (buffer[cursor + index] != directivePrefix[index]) {
+                return false
+            }
+        }
+
+        return cursor + directivePrefix.length <= lineEndWithoutSeparator(offset)
+    }
+
+    private fun isWhitespaceLine(offset: Int): Boolean {
+        val end = lineEndWithoutSeparator(offset)
+        for (index in offset until end) {
+            if (!buffer[index].isWhitespace()) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun lineEnd(offset: Int): Int {
+        var cursor = offset
+        while (cursor < endOffset) {
+            val character = buffer[cursor]
+            cursor++
+            if (character == '\n') {
+                return cursor
+            }
+            if (character == '\r') {
+                if (cursor < endOffset && buffer[cursor] == '\n') {
+                    cursor++
+                }
+                return cursor
+            }
+        }
+        return endOffset
+    }
+
+    private fun lineEndWithoutSeparator(offset: Int): Int {
+        var cursor = offset
+        while (cursor < endOffset) {
+            val character = buffer[cursor]
+            if (character == '\n' || character == '\r') {
+                return cursor
+            }
+            cursor++
+        }
+        return endOffset
+    }
+
+    private companion object {
+        const val BEFORE_FIRST_ENTRY = 0
+        const val AFTER_MODULE_HEADER = 1
+        const val AFTER_FILE_HEADER = 2
+    }
+}

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataParser.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataParser.kt
@@ -1,0 +1,73 @@
+package org.jetbrains.kotlin.test.helper.lang
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.PsiBuilder
+import com.intellij.lang.PsiParser
+import com.intellij.psi.tree.IElementType
+
+class MultifileTestDataParser : PsiParser {
+    override fun parse(
+        root: IElementType,
+        builder: PsiBuilder,
+    ): ASTNode {
+        val rootMarker = builder.mark()
+
+        parsePreamble(builder)
+
+        while (!builder.eof()) {
+            if (!parseEntry(builder)) {
+                val invalid = builder.mark()
+                builder.advanceLexer()
+                invalid.error("Unexpected multifile test data token")
+            }
+        }
+
+        rootMarker.done(root)
+        return builder.treeBuilt
+    }
+
+    private fun parsePreamble(builder: PsiBuilder) {
+        if (builder.tokenType == MULTIFILE_PREAMBLE_TEXT) {
+            val preamble = builder.mark()
+            while (builder.tokenType == MULTIFILE_PREAMBLE_TEXT) {
+                builder.advanceLexer()
+            }
+            preamble.done(MULTIFILE_PREAMBLE)
+        }
+    }
+
+    private fun parseEntry(builder: PsiBuilder): Boolean {
+        if (builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
+            return false
+        }
+
+        val entry = builder.mark()
+
+        if (builder.tokenType == MULTIFILE_MODULE_LINE) {
+            val moduleHeader = builder.mark()
+            builder.advanceLexer()
+            moduleHeader.done(MULTIFILE_MODULE_HEADER)
+        }
+
+        if (builder.tokenType == MULTIFILE_FILE_LINE) {
+            val fileHeader = builder.mark()
+            builder.advanceLexer()
+            fileHeader.done(MULTIFILE_FILE_HEADER)
+        } else {
+            builder.error("Expected // FILE: directive")
+            entry.done(MULTIFILE_ENTRY)
+            return true
+        }
+
+        if (builder.tokenType != null && builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
+            val content = builder.mark()
+            while (builder.tokenType != null && builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
+                builder.advanceLexer()
+            }
+            content.done(MULTIFILE_FILE_CONTENT)
+        }
+
+        entry.done(MULTIFILE_ENTRY)
+        return true
+    }
+}

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataParserDefinition.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataParserDefinition.kt
@@ -1,0 +1,45 @@
+package org.jetbrains.kotlin.test.helper.lang
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.lang.ASTNode
+import com.intellij.lang.ParserDefinition
+import com.intellij.lang.ParserDefinition.SpaceRequirements
+import com.intellij.lang.PsiParser
+import com.intellij.lexer.Lexer
+import com.intellij.openapi.project.Project
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.tree.IFileElementType
+import com.intellij.psi.tree.TokenSet
+
+class MultifileTestDataParserDefinition : ParserDefinition {
+    override fun createLexer(project: Project?): Lexer = MultifileTestDataLexer()
+
+    override fun createParser(project: Project?): PsiParser = MultifileTestDataParser()
+
+    override fun getFileNodeType(): IFileElementType = MULTIFILE_TEXT_FILE
+
+    override fun getWhitespaceTokens(): TokenSet = MULTIFILE_WHITE_SPACES
+
+    override fun getCommentTokens(): TokenSet = MULTIFILE_COMMENT_TOKENS
+
+    override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY
+
+    override fun createElement(node: ASTNode): PsiElement =
+        when (node.elementType) {
+            MULTIFILE_PREAMBLE -> MultifileTestDataPreamble(node)
+            MULTIFILE_ENTRY -> MultifileTestDataEntry(node)
+            MULTIFILE_MODULE_HEADER -> MultifileTestDataModuleHeader(node)
+            MULTIFILE_FILE_HEADER -> MultifileTestDataFileHeader(node)
+            MULTIFILE_FILE_CONTENT -> MultifileTestDataFileContent(node)
+            else -> ASTWrapperPsiElement(node)
+        }
+
+    override fun createFile(viewProvider: FileViewProvider): PsiFile = MultifileTestDataTextFileImpl(viewProvider)
+
+    override fun spaceExistenceTypeBetweenTokens(
+        left: ASTNode,
+        right: ASTNode,
+    ): SpaceRequirements = SpaceRequirements.MAY
+}

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataPsi.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataPsi.kt
@@ -11,7 +11,31 @@ import com.intellij.psi.LiteralTextEscaper
 import com.intellij.psi.PsiLanguageInjectionHost
 import com.intellij.psi.util.PsiTreeUtil
 
-internal class MultifileTestDataPreamble(node: ASTNode) : ASTWrapperPsiElement(node)
+internal abstract class InjectableLanguageInjectionHost(node: ASTNode) : ASTWrapperPsiElement(node), PsiLanguageInjectionHost {
+    override fun isValidHost(): Boolean = true
+
+    override fun updateText(text: String): PsiLanguageInjectionHost = this
+
+    override fun createLiteralTextEscaper(): LiteralTextEscaper<PsiLanguageInjectionHost> =
+        object : LiteralTextEscaper<PsiLanguageInjectionHost>(this) {
+            override fun decode(
+                rangeInsideHost: TextRange,
+                outChars: StringBuilder,
+            ): Boolean {
+                outChars.append(rangeInsideHost.substring(myHost.text))
+                return true
+            }
+
+            override fun getOffsetInHost(
+                offsetInDecoded: Int,
+                rangeInsideHost: TextRange,
+            ): Int = (rangeInsideHost.startOffset + offsetInDecoded).coerceAtMost(rangeInsideHost.endOffset)
+
+            override fun isOneLine(): Boolean = false
+        }
+}
+
+internal class MultifileTestDataPreamble(node: ASTNode) : InjectableLanguageInjectionHost(node)
 
 internal class MultifileTestDataEntry(node: ASTNode) : ASTWrapperPsiElement(node) {
     val moduleHeader: MultifileTestDataModuleHeader?
@@ -71,29 +95,7 @@ internal class MultifileTestDataFileHeader(node: ASTNode) : MultifileTestDataDir
             .let { fileType -> (fileType as? LanguageFileType)?.language ?: PlainTextLanguage.INSTANCE }
 }
 
-internal class MultifileTestDataFileContent(node: ASTNode) : ASTWrapperPsiElement(node), PsiLanguageInjectionHost {
+internal class MultifileTestDataFileContent(node: ASTNode) : InjectableLanguageInjectionHost(node) {
     val entry: MultifileTestDataEntry?
         get() = parent as? MultifileTestDataEntry
-
-    override fun isValidHost(): Boolean = true
-
-    override fun updateText(text: String): PsiLanguageInjectionHost = this
-
-    override fun createLiteralTextEscaper(): LiteralTextEscaper<out PsiLanguageInjectionHost> =
-        object : LiteralTextEscaper<MultifileTestDataFileContent>(this) {
-            override fun decode(
-                rangeInsideHost: TextRange,
-                outChars: StringBuilder,
-            ): Boolean {
-                outChars.append(rangeInsideHost.substring(myHost.text))
-                return true
-            }
-
-            override fun getOffsetInHost(
-                offsetInDecoded: Int,
-                rangeInsideHost: TextRange,
-            ): Int = (rangeInsideHost.startOffset + offsetInDecoded).coerceAtMost(rangeInsideHost.endOffset)
-
-            override fun isOneLine(): Boolean = false
-        }
 }

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataPsi.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataPsi.kt
@@ -1,0 +1,99 @@
+package org.jetbrains.kotlin.test.helper.lang
+
+import com.intellij.lang.Language
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.lang.ASTNode
+import com.intellij.openapi.fileTypes.FileTypeRegistry
+import com.intellij.openapi.fileTypes.LanguageFileType
+import com.intellij.openapi.fileTypes.PlainTextLanguage
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.LiteralTextEscaper
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.util.PsiTreeUtil
+
+internal class MultifileTestDataPreamble(node: ASTNode) : ASTWrapperPsiElement(node)
+
+internal class MultifileTestDataEntry(node: ASTNode) : ASTWrapperPsiElement(node) {
+    val moduleHeader: MultifileTestDataModuleHeader?
+        get() = PsiTreeUtil.getChildOfType(this, MultifileTestDataModuleHeader::class.java)
+
+    val fileHeader: MultifileTestDataFileHeader?
+        get() = PsiTreeUtil.getChildOfType(this, MultifileTestDataFileHeader::class.java)
+
+    val content: MultifileTestDataFileContent?
+        get() = PsiTreeUtil.getChildOfType(this, MultifileTestDataFileContent::class.java)
+
+    val placeholderText: String
+        get() = buildString {
+            append("// ")
+            val moduleName = moduleHeader?.moduleName?.takeIf(String::isNotBlank)
+            moduleName?.let {
+                append("MODULE: ")
+                append(it)
+            }
+            fileHeader?.fileName?.takeIf(String::isNotBlank)?.let {
+                if (moduleName != null) append(" ")
+                append("FILE: ")
+                append(it)
+            }
+        }
+}
+
+internal abstract class MultifileTestDataDirective(protected val directiveName: String, node: ASTNode) : ASTWrapperPsiElement(node) {
+    protected fun directiveValue(): String =
+        this.text.lineSequence().firstOrNull().orEmpty()
+            .removePrefix("//")
+            .trimStart()
+            .removePrefix("$directiveName:")
+            .trim()
+
+    val placeholderText: String
+        get() = buildString {
+            append("// ")
+            append(directiveName)
+            append(": ")
+            append(directiveValue())
+        }
+}
+
+internal class MultifileTestDataModuleHeader(node: ASTNode) : MultifileTestDataDirective("MODULE", node) {
+    val moduleName: String
+        get() = directiveValue()
+}
+
+internal class MultifileTestDataFileHeader(node: ASTNode) : MultifileTestDataDirective("FILE", node) {
+    val fileName: String
+        get() = directiveValue()
+
+    val injectedLanguage: Language
+        get() = FileTypeRegistry.getInstance()
+            .getFileTypeByFileName(fileName)
+            .let { fileType -> (fileType as? LanguageFileType)?.language ?: PlainTextLanguage.INSTANCE }
+}
+
+internal class MultifileTestDataFileContent(node: ASTNode) : ASTWrapperPsiElement(node), PsiLanguageInjectionHost {
+    val entry: MultifileTestDataEntry?
+        get() = parent as? MultifileTestDataEntry
+
+    override fun isValidHost(): Boolean = true
+
+    override fun updateText(text: String): PsiLanguageInjectionHost = this
+
+    override fun createLiteralTextEscaper(): LiteralTextEscaper<out PsiLanguageInjectionHost> =
+        object : LiteralTextEscaper<MultifileTestDataFileContent>(this) {
+            override fun decode(
+                rangeInsideHost: TextRange,
+                outChars: StringBuilder,
+            ): Boolean {
+                outChars.append(rangeInsideHost.substring(myHost.text))
+                return true
+            }
+
+            override fun getOffsetInHost(
+                offsetInDecoded: Int,
+                rangeInsideHost: TextRange,
+            ): Int = (rangeInsideHost.startOffset + offsetInDecoded).coerceAtMost(rangeInsideHost.endOffset)
+
+            override fun isOneLine(): Boolean = false
+        }
+}

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataTextFileImpl.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataTextFileImpl.kt
@@ -1,0 +1,39 @@
+package org.jetbrains.kotlin.test.helper.lang
+
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.psi.FileViewProvider
+import com.intellij.psi.HintedReferenceHost
+import com.intellij.psi.PsiElementVisitor
+import com.intellij.psi.PsiPlainTextFile
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceService.Hints
+import com.intellij.psi.impl.source.PsiFileImpl
+import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry
+import com.intellij.psi.util.PsiTreeUtil
+
+class MultifileTestDataTextFileImpl(viewProvider: FileViewProvider) :
+    PsiFileImpl(MULTIFILE_TEXT_FILE, MULTIFILE_TEXT_FILE, viewProvider),
+    PsiPlainTextFile,
+    HintedReferenceHost {
+    override fun accept(visitor: PsiElementVisitor) {
+        visitor.visitFile(this)
+    }
+
+    override fun toString(): String =
+        "PsiFile(multifile test data): $name"
+
+    override fun getFileType(): FileType =
+        MultifileTestDataFileType
+
+    override fun getReferences(): Array<PsiReference?> =
+        ReferenceProvidersRegistry.getReferencesFromProviders(this)
+
+    override fun getReferences(hints: Hints): Array<PsiReference?> =
+        ReferenceProvidersRegistry.getReferencesFromProviders(this, hints)
+
+    override fun shouldAskParentForReferences(hints: Hints): Boolean =
+        false
+
+    internal val entries: List<MultifileTestDataEntry>
+        get() = PsiTreeUtil.getChildrenOfTypeAsList(this, MultifileTestDataEntry::class.java)
+}

--- a/src/org/jetbrains/kotlin/test/helper/reference/DirectiveReferenceContributor.kt
+++ b/src/org/jetbrains/kotlin/test/helper/reference/DirectiveReferenceContributor.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlin.test.helper.reference
 
+import com.intellij.injected.editor.VirtualFileWindow
 import com.intellij.openapi.util.TextRange
 import com.intellij.patterns.PlatformPatterns
 import com.intellij.psi.*
@@ -18,9 +19,10 @@ class DirectiveReferenceContributor : PsiReferenceContributor() {
                     element: PsiElement,
                     context: ProcessingContext
                 ): Array<PsiReference> {
-                    val file =
-                        element.containingFile?.virtualFile ?: return PsiReference.EMPTY_ARRAY
-                    if (file.getTestDataType(element.project) == null) return PsiReference.EMPTY_ARRAY
+                    element.containingFile?.virtualFile
+                        ?.let { (it as? VirtualFileWindow)?.delegate ?: it }
+                        ?.takeIf { it.getTestDataType(element.project) != null }
+                        ?: return PsiReference.EMPTY_ARRAY
 
                     val text = element.text
                     val refs = mutableListOf<PsiReference>()

--- a/src/org/jetbrains/kotlin/test/helper/testFileUtils.kt
+++ b/src/org/jetbrains/kotlin/test/helper/testFileUtils.kt
@@ -29,7 +29,7 @@ val VirtualFile.simpleNameUntilFirstDot: String
     }
 
 
-private val supportedExtensions = listOf("kt", "kts", "args", "can-freeze-ide")
+private val supportedExtensions = listOf("kt", "kts", "args", "can-freeze-ide", "test")
 
 enum class TestDataType {
     File,

--- a/test/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexerTest.kt
+++ b/test/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexerTest.kt
@@ -1,0 +1,88 @@
+package org.jetbrains.kotlin.test.helper.lang
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MultifileTestDataLexerTest {
+    @Test
+    fun `keeps preamble before first file and parses subsequent entries`() {
+        assertEquals(
+            listOf(
+                "MULTIFILE_PREAMBLE_TEXT:// FIR_IDENTICAL\\n// SKIP_TXT\\n\\n",
+                "MULTIFILE_MODULE_LINE:// MODULE: moduleA\\n",
+                "MULTIFILE_FILE_LINE:// FILE: a.kt\\n",
+                "MULTIFILE_CONTENT_TEXT:package sample\\n\\nclass A\\n",
+                "MULTIFILE_FILE_LINE:// FILE: b.java\\n",
+                "MULTIFILE_CONTENT_TEXT:class B {}",
+            ),
+            tokenize(
+                """
+                // FIR_IDENTICAL
+                // SKIP_TXT
+                
+                // MODULE: moduleA
+                // FILE: a.kt
+                package sample
+                
+                class A
+                // FILE: b.java
+                class B {}
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `does not split on indented file marker inside content`() {
+        assertEquals(
+            listOf(
+                "MULTIFILE_FILE_LINE:// FILE: sample.kt\\n",
+                "MULTIFILE_CONTENT_TEXT:fun example() {\\n    // FILE: not-a-header.kt\\n}",
+            ),
+            tokenize(
+                """
+                // FILE: sample.kt
+                fun example() {
+                    // FILE: not-a-header.kt
+                }
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `treats module header inside content as plain text when no file follows`() {
+        assertEquals(
+            listOf(
+                "MULTIFILE_FILE_LINE:// FILE: sample.kt\\n",
+                "MULTIFILE_CONTENT_TEXT:fun example() {\\n// MODULE: not-structural\\nprintln(42)\\n}",
+            ),
+            tokenize(
+                """
+                // FILE: sample.kt
+                fun example() {
+                // MODULE: not-structural
+                println(42)
+                }
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    private fun tokenize(text: String): List<String> {
+        val lexer = MultifileTestDataLexer()
+        lexer.start(text)
+
+        val tokens = mutableListOf<String>()
+        while (lexer.tokenType != null) {
+            tokens += "${lexer.tokenType}:${
+                text.substring(lexer.tokenStart, lexer.tokenEnd)
+                    .replace("\r", "\\r")
+                    .replace("\n", "\\n")
+            }"
+            lexer.advance()
+        }
+
+        return tokens
+    }
+}


### PR DESCRIPTION
Adds folding to multifile test data files

and file separators for `*.test` files

<img width="1084" height="1808" alt="image" src="https://github.com/user-attachments/assets/e42b16b4-1eb7-4d4f-b45e-5eb63835e01f" />
