### PR TITLE
Settings enh

### DIFF
--- a/resources/icons/multifile_testdata.svg
+++ b/resources/icons/multifile_testdata.svg
@@ -12,10 +12,10 @@
         </mask>
     </defs>
     <g mask="url(#cutout-mask)">
-        <rect x="2.5" y="2.5" width="11" height="11" rx="1.5" fill="#E7EFFD" stroke="#3574F0"/>
-        <rect x="5" y="4" width="6" height="2" rx="0.5" fill="#3574F0"/>
-        <rect x="5" y="7" width="6" height="2" rx="0.5" fill="#3574F0"/>
-        <rect x="5" y="10" width="6" height="2" rx="0.5" fill="#3574F0"/>
+        <rect x="2" y="2" width="11" height="11" rx="1.5" fill="#E7EFFD" stroke="#3574F0"/>
+        <rect x="4" y="3.5" width="7" height="2" rx="0.5" fill="#3574F0"/>
+        <rect x="4" y="6.5" width="7" height="2" rx="0.5" fill="#3574F0"/>
+        <rect x="4" y="9.5" width="7" height="2" rx="0.5" fill="#3574F0"/>
     </g>
     <g>
         <path d="M10 10H14.6445L12.6748 11.9697C12.3819 12.2626 12.3819 12.7374 12.6748 13.0303L14.6445 15H10V10Z"

--- a/src/org/jetbrains/kotlin/test/helper/TestDataPluginSettings.kt
+++ b/src/org/jetbrains/kotlin/test/helper/TestDataPluginSettings.kt
@@ -14,6 +14,7 @@ import com.intellij.ui.PanelWithButtons
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Panel
 import com.intellij.ui.dsl.builder.panel
+import org.jetbrains.kotlin.test.helper.ui.settings.IgnoredLanguagesForInjectionPanel
 import org.jetbrains.kotlin.test.helper.ui.settings.RelatedFileSearchPathsPanel
 import org.jetbrains.kotlin.test.helper.ui.settings.TestDataPathEntriesPanel
 import org.jetbrains.kotlin.test.helper.ui.settings.TestTagsEntriesPanel
@@ -27,7 +28,13 @@ class PluginSettingsState(
     var testDataDirectories: MutableList<VirtualFile>,
     var relatedFileSearchPaths: MutableList<Pair<VirtualFile, List<String>>>,
     var testTags: MutableList<Pair<String, List<String>>>,
+    var ignoredLanguagesForInjection: MutableList<String>,
 )
+
+internal val defaultIgnoredLanguagesForInjection: List<String> =
+    listOf("Kotlin", "Java")
+
+private const val TEST_DATA_FILE_PLACEHOLDER: String = "$" + "TEST_DATA_FILE$"
 
 @Service(Service.Level.PROJECT)
 @State(name = "TestDataPluginSettings", storages = [(Storage("kotlinTestDataPluginTestDataPaths.xml"))])
@@ -48,12 +55,20 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
 
     var testTags: Map<String, Array<String>> = emptyMap()
 
+    var ignoredLanguagesForInjection: Array<String> = defaultIgnoredLanguagesForInjection.toTypedArray()
+
     override fun getState(): TestDataPathsConfiguration {
         return this
     }
 
     override fun loadState(state: TestDataPathsConfiguration) {
-        loadState(state.testDataFiles, state.testDataDirectories, state.relatedFilesSearchPaths, state.testTags)
+        loadState(
+            state.testDataFiles,
+            state.testDataDirectories,
+            state.relatedFilesSearchPaths,
+            state.testTags,
+            state.ignoredLanguagesForInjection,
+        )
     }
 
     fun loadState(
@@ -61,6 +76,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
         newTestDataDirectories: List<VirtualFile>,
         newRelatedFilesSearchPaths: List<Pair<VirtualFile, List<String>>>,
         newTestTags: List<Pair<String, List<String>>>,
+        newIgnoredLanguagesForInjection: List<String>,
     ) {
         loadState(
             newTestDataFiles.map { it.path }.toTypedArray(),
@@ -73,6 +89,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
                 keySelector = { it.first },
                 valueTransform = { it.second.toTypedArray() }
             ),
+            newIgnoredLanguagesForInjection.toTypedArray(),
         )
     }
 
@@ -81,11 +98,13 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
         newTestDataDirectories: Array<String>,
         newRelatedFilesSearchPaths: Map<String, Array<String>>,
         newTestTags: Map<String, Array<String>>,
+        newIgnoredLanguagesForInjection: Array<String>,
     ) {
         testDataFiles = newTestDataFiles.copyOf()
         testDataDirectories = newTestDataDirectories.copyOf()
         relatedFilesSearchPaths = newRelatedFilesSearchPaths.toMap()
         testTags = newTestTags.toMap()
+        ignoredLanguagesForInjection = newIgnoredLanguagesForInjection.copyOf()
     }
 
     /**
@@ -113,7 +132,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
                     val testDataFileReplacement = baseFilePath.relativeTo(testDataSubdirPath).parent
                         ?.resolve(simpleNameUntilFirstDot)?.pathString
                         ?: simpleNameUntilFirstDot
-                    val actualSearchPath = searchPath.replace("\$TEST_DATA_FILE$", testDataFileReplacement).trim()
+                    val actualSearchPath = searchPath.replace(TEST_DATA_FILE_PLACEHOLDER, testDataFileReplacement).trim()
 
                     if (run(actualSearchPath))
                         return true
@@ -152,7 +171,8 @@ class TestDataPathsConfigurable(private val project: Project) :
         testDataFiles = resetTestData(isFiles = true),
         testDataDirectories = resetTestData(isFiles = false),
         relatedFileSearchPaths = resetRelatedFileSearchPaths(),
-        testTags = resetTestTags()
+        testTags = resetTestTags(),
+        ignoredLanguagesForInjection = resetIgnoredLanguagesForInjection(),
     )
 
     private var testDataFiles: MutableList<VirtualFile>
@@ -170,6 +190,10 @@ class TestDataPathsConfigurable(private val project: Project) :
     private var testTags: MutableList<Pair<String, List<String>>>
         get() = state.testTags
         set(value) { state.testTags = value }
+
+    private var ignoredLanguagesForInjection: MutableList<String>
+        get() = state.ignoredLanguagesForInjection
+        set(value) { state.ignoredLanguagesForInjection = value }
 
     // -------------------------------- state initialization --------------------------------
 
@@ -191,6 +215,10 @@ class TestDataPathsConfigurable(private val project: Project) :
         }
     }
 
+    private fun resetIgnoredLanguagesForInjection(): MutableList<String> {
+        return configuration.ignoredLanguagesForInjection.toMutableList()
+    }
+
     // -------------------------------- panels --------------------------------
 
     private val testDataFilesPathPanel: TestDataPathEntriesPanel by lazy {
@@ -209,6 +237,10 @@ class TestDataPathsConfigurable(private val project: Project) :
         TestTagsEntriesPanel(state)
     }
 
+    private val ignoredLanguagesForInjectionPanel: IgnoredLanguagesForInjectionPanel by lazy {
+        IgnoredLanguagesForInjectionPanel(state)
+    }
+
     override fun createPanel(): DialogPanel {
         fun Panel.panelRow(title: String, panel: PanelWithButtons) {
             row(title) {}
@@ -223,6 +255,7 @@ class TestDataPathsConfigurable(private val project: Project) :
             panelRow("Test data directories:", testDataDirectoriesPathPanel)
             panelRow("Related file search paths:", relatedFilesSearchPathsPanel)
             panelRow("Test tags:", testTagsPanel)
+            panelRow("Ignored injected languages:", ignoredLanguagesForInjectionPanel)
         }
     }
 
@@ -245,20 +278,28 @@ class TestDataPathsConfigurable(private val project: Project) :
 
     private fun relatedFilesSearchPathsModified(): Boolean {
         val pathsFromConfiguration = configuration.relatedFilesSearchPaths
-        if (pathsFromConfiguration.size != relatedFileSearchPaths.size) return true
-        return pathsFromConfiguration.asSequence().zip(relatedFileSearchPaths.asSequence())
+        return pathsFromConfiguration.size != relatedFileSearchPaths.size || pathsFromConfiguration.asSequence().zip(relatedFileSearchPaths.asSequence())
             .any { it.first.key != it.second.first.path || it.first.value.toList() != it.second.second }
     }
 
     private fun testTagsModified(): Boolean {
         val tagsFromConfiguration = configuration.testTags
-        if (tagsFromConfiguration.size != testTags.size) return true
-        return tagsFromConfiguration.asSequence().zip(testTags.asSequence())
+        return tagsFromConfiguration.size != testTags.size || tagsFromConfiguration.asSequence().zip(testTags.asSequence())
             .any { it.first.key != it.second.first || it.first.value.toList() != it.second.second }
     }
 
+    private fun ignoredLanguagesForInjectionModified(): Boolean {
+        val ignoredLanguagesFromConfiguration = configuration.ignoredLanguagesForInjection
+        return ignoredLanguagesFromConfiguration.size != ignoredLanguagesForInjection.size || ignoredLanguagesFromConfiguration.asSequence().zip(ignoredLanguagesForInjection.asSequence())
+            .any { it.first != it.second }
+    }
+
     override fun isModified(): Boolean {
-        return testDataModified(isFiles = true) || testDataModified(isFiles = false) || relatedFilesSearchPathsModified() || testTagsModified()
+        return testDataModified(isFiles = true) ||
+            testDataModified(isFiles = false) ||
+            relatedFilesSearchPathsModified() ||
+            testTagsModified() ||
+            ignoredLanguagesForInjectionModified()
     }
 
     override fun reset() {
@@ -266,13 +307,17 @@ class TestDataPathsConfigurable(private val project: Project) :
         testDataFiles = resetTestData(isFiles = true)
         testDataDirectories = resetTestData(isFiles = false)
         relatedFileSearchPaths = resetRelatedFileSearchPaths()
+        testTags = resetTestTags()
+        ignoredLanguagesForInjection = resetIgnoredLanguagesForInjection()
         (testDataFilesPathPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
         (testDataDirectoriesPathPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
         (relatedFilesSearchPathsPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
+        (testTagsPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
+        (ignoredLanguagesForInjectionPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
     }
 
     override fun apply() {
         super.apply()
-        configuration.loadState(testDataFiles, testDataDirectories, relatedFileSearchPaths, testTags)
+        configuration.loadState(testDataFiles, testDataDirectories, relatedFileSearchPaths, testTags, ignoredLanguagesForInjection)
     }
 }

--- a/src/org/jetbrains/kotlin/test/helper/TestDataPluginSettings.kt
+++ b/src/org/jetbrains/kotlin/test/helper/TestDataPluginSettings.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBTextField
 import com.intellij.ui.PanelWithButtons
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Panel
@@ -19,6 +20,8 @@ import org.jetbrains.kotlin.test.helper.ui.settings.IgnoredLanguagesForInjection
 import org.jetbrains.kotlin.test.helper.ui.settings.RelatedFileSearchPathsPanel
 import org.jetbrains.kotlin.test.helper.ui.settings.TestDataPathEntriesPanel
 import org.jetbrains.kotlin.test.helper.ui.settings.TestTagsEntriesPanel
+import javax.swing.event.DocumentEvent
+import javax.swing.event.DocumentListener
 import javax.swing.table.AbstractTableModel
 import kotlin.io.path.Path
 import kotlin.io.path.pathString
@@ -31,10 +34,14 @@ class PluginSettingsState(
     var testTags: MutableList<Pair<String, List<String>>>,
     var ignoredLanguagesForInjection: MutableList<String>,
     var multifilePartsSeparator: Boolean,
+    var directiveClassId: String,
 )
 
 internal val defaultIgnoredLanguagesForInjection: List<String> =
     listOf("Kotlin", "Java")
+
+internal const val defaultDirectiveClassId: String =
+    "org.jetbrains.kotlin.test.directives.model.Directive"
 
 private const val TEST_DATA_FILE_PLACEHOLDER: String = "$" + "TEST_DATA_FILE$"
 
@@ -61,6 +68,8 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
 
     var multifilePartsSeparator: Boolean = true
 
+    var directiveClassId: String = defaultDirectiveClassId
+
     override fun getState(): TestDataPathsConfiguration {
         return this
     }
@@ -73,6 +82,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
             state.testTags,
             state.ignoredLanguagesForInjection,
             state.multifilePartsSeparator,
+            state.directiveClassId,
         )
     }
 
@@ -83,6 +93,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
         newTestTags: List<Pair<String, List<String>>>,
         newIgnoredLanguagesForInjection: List<String>,
         newMultifilePartsSeparator: Boolean,
+        newDirectiveClassId: String,
     ) {
         loadState(
             newTestDataFiles.map { it.path }.toTypedArray(),
@@ -97,6 +108,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
             ),
             newIgnoredLanguagesForInjection.toTypedArray(),
             newMultifilePartsSeparator,
+            newDirectiveClassId,
         )
     }
 
@@ -107,6 +119,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
         newTestTags: Map<String, Array<String>>,
         newIgnoredLanguagesForInjection: Array<String>,
         newMultifilePartsSeparator: Boolean,
+        newDirectiveClassId: String,
     ) {
         testDataFiles = newTestDataFiles.copyOf()
         testDataDirectories = newTestDataDirectories.copyOf()
@@ -114,6 +127,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
         testTags = newTestTags.toMap()
         ignoredLanguagesForInjection = newIgnoredLanguagesForInjection.copyOf()
         multifilePartsSeparator = newMultifilePartsSeparator
+        directiveClassId = newDirectiveClassId
     }
 
     /**
@@ -183,6 +197,7 @@ class TestDataPathsConfigurable(private val project: Project) :
         testTags = resetTestTags(),
         ignoredLanguagesForInjection = resetIgnoredLanguagesForInjection(),
         multifilePartsSeparator = resetMultifilePartsSeparator(),
+        directiveClassId = resetDirectiveClassId(),
     )
 
     private var testDataFiles: MutableList<VirtualFile>
@@ -208,6 +223,10 @@ class TestDataPathsConfigurable(private val project: Project) :
     private var multifilePartsSeparator: Boolean
         get() = state.multifilePartsSeparator
         set(value) { state.multifilePartsSeparator = value }
+
+    private var directiveClassId: String
+        get() = state.directiveClassId
+        set(value) { state.directiveClassId = value }
 
     // -------------------------------- state initialization --------------------------------
 
@@ -235,6 +254,10 @@ class TestDataPathsConfigurable(private val project: Project) :
 
     private fun resetMultifilePartsSeparator(): Boolean {
         return configuration.multifilePartsSeparator
+    }
+
+    private fun resetDirectiveClassId(): String {
+        return configuration.directiveClassId
     }
 
     // -------------------------------- panels --------------------------------
@@ -267,6 +290,24 @@ class TestDataPathsConfigurable(private val project: Project) :
         }
     }
 
+    private val directiveClassIdField: JBTextField by lazy {
+        JBTextField(state.directiveClassId).apply {
+            document.addDocumentListener(object : DocumentListener {
+                override fun insertUpdate(e: DocumentEvent?) {
+                    state.directiveClassId = text.trim()
+                }
+
+                override fun removeUpdate(e: DocumentEvent?) {
+                    state.directiveClassId = text.trim()
+                }
+
+                override fun changedUpdate(e: DocumentEvent?) {
+                    state.directiveClassId = text.trim()
+                }
+            })
+        }
+    }
+
     override fun createPanel(): DialogPanel {
         fun Panel.panelRow(title: String, panel: PanelWithButtons) {
             row(title) {}
@@ -284,6 +325,9 @@ class TestDataPathsConfigurable(private val project: Project) :
             panelRow("Ignored injected languages:", ignoredLanguagesForInjectionPanel)
             row {
                 cell(multifilePartsSeparatorCheckbox)
+            }
+            row("Directive class id:") {
+                cell(directiveClassIdField).align(AlignX.FILL)
             }
         }
     }
@@ -327,13 +371,18 @@ class TestDataPathsConfigurable(private val project: Project) :
         return configuration.multifilePartsSeparator != multifilePartsSeparator
     }
 
+    private fun directiveClassIdModified(): Boolean {
+        return configuration.directiveClassId != directiveClassId
+    }
+
     override fun isModified(): Boolean {
         return testDataModified(isFiles = true) ||
             testDataModified(isFiles = false) ||
             relatedFilesSearchPathsModified() ||
             testTagsModified() ||
             ignoredLanguagesForInjectionModified() ||
-            multifilePartsSeparatorModified()
+            multifilePartsSeparatorModified() ||
+            directiveClassIdModified()
     }
 
     override fun reset() {
@@ -344,7 +393,9 @@ class TestDataPathsConfigurable(private val project: Project) :
         testTags = resetTestTags()
         ignoredLanguagesForInjection = resetIgnoredLanguagesForInjection()
         multifilePartsSeparator = resetMultifilePartsSeparator()
+        directiveClassId = resetDirectiveClassId()
         multifilePartsSeparatorCheckbox.isSelected = multifilePartsSeparator
+        directiveClassIdField.text = directiveClassId
         (testDataFilesPathPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
         (testDataDirectoriesPathPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
         (relatedFilesSearchPathsPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
@@ -361,6 +412,7 @@ class TestDataPathsConfigurable(private val project: Project) :
             testTags,
             ignoredLanguagesForInjection,
             multifilePartsSeparator,
+            directiveClassId,
         )
     }
 }

--- a/src/org/jetbrains/kotlin/test/helper/TestDataPluginSettings.kt
+++ b/src/org/jetbrains/kotlin/test/helper/TestDataPluginSettings.kt
@@ -10,6 +10,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.ui.components.JBCheckBox
 import com.intellij.ui.PanelWithButtons
 import com.intellij.ui.dsl.builder.AlignX
 import com.intellij.ui.dsl.builder.Panel
@@ -29,6 +30,7 @@ class PluginSettingsState(
     var relatedFileSearchPaths: MutableList<Pair<VirtualFile, List<String>>>,
     var testTags: MutableList<Pair<String, List<String>>>,
     var ignoredLanguagesForInjection: MutableList<String>,
+    var multifilePartsSeparator: Boolean,
 )
 
 internal val defaultIgnoredLanguagesForInjection: List<String> =
@@ -57,6 +59,8 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
 
     var ignoredLanguagesForInjection: Array<String> = defaultIgnoredLanguagesForInjection.toTypedArray()
 
+    var multifilePartsSeparator: Boolean = true
+
     override fun getState(): TestDataPathsConfiguration {
         return this
     }
@@ -68,6 +72,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
             state.relatedFilesSearchPaths,
             state.testTags,
             state.ignoredLanguagesForInjection,
+            state.multifilePartsSeparator,
         )
     }
 
@@ -77,6 +82,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
         newRelatedFilesSearchPaths: List<Pair<VirtualFile, List<String>>>,
         newTestTags: List<Pair<String, List<String>>>,
         newIgnoredLanguagesForInjection: List<String>,
+        newMultifilePartsSeparator: Boolean,
     ) {
         loadState(
             newTestDataFiles.map { it.path }.toTypedArray(),
@@ -90,6 +96,7 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
                 valueTransform = { it.second.toTypedArray() }
             ),
             newIgnoredLanguagesForInjection.toTypedArray(),
+            newMultifilePartsSeparator,
         )
     }
 
@@ -99,12 +106,14 @@ class TestDataPathsConfiguration : PersistentStateComponent<TestDataPathsConfigu
         newRelatedFilesSearchPaths: Map<String, Array<String>>,
         newTestTags: Map<String, Array<String>>,
         newIgnoredLanguagesForInjection: Array<String>,
+        newMultifilePartsSeparator: Boolean,
     ) {
         testDataFiles = newTestDataFiles.copyOf()
         testDataDirectories = newTestDataDirectories.copyOf()
         relatedFilesSearchPaths = newRelatedFilesSearchPaths.toMap()
         testTags = newTestTags.toMap()
         ignoredLanguagesForInjection = newIgnoredLanguagesForInjection.copyOf()
+        multifilePartsSeparator = newMultifilePartsSeparator
     }
 
     /**
@@ -173,6 +182,7 @@ class TestDataPathsConfigurable(private val project: Project) :
         relatedFileSearchPaths = resetRelatedFileSearchPaths(),
         testTags = resetTestTags(),
         ignoredLanguagesForInjection = resetIgnoredLanguagesForInjection(),
+        multifilePartsSeparator = resetMultifilePartsSeparator(),
     )
 
     private var testDataFiles: MutableList<VirtualFile>
@@ -194,6 +204,10 @@ class TestDataPathsConfigurable(private val project: Project) :
     private var ignoredLanguagesForInjection: MutableList<String>
         get() = state.ignoredLanguagesForInjection
         set(value) { state.ignoredLanguagesForInjection = value }
+
+    private var multifilePartsSeparator: Boolean
+        get() = state.multifilePartsSeparator
+        set(value) { state.multifilePartsSeparator = value }
 
     // -------------------------------- state initialization --------------------------------
 
@@ -219,6 +233,10 @@ class TestDataPathsConfigurable(private val project: Project) :
         return configuration.ignoredLanguagesForInjection.toMutableList()
     }
 
+    private fun resetMultifilePartsSeparator(): Boolean {
+        return configuration.multifilePartsSeparator
+    }
+
     // -------------------------------- panels --------------------------------
 
     private val testDataFilesPathPanel: TestDataPathEntriesPanel by lazy {
@@ -241,6 +259,14 @@ class TestDataPathsConfigurable(private val project: Project) :
         IgnoredLanguagesForInjectionPanel(state)
     }
 
+    private val multifilePartsSeparatorCheckbox: JBCheckBox by lazy {
+        JBCheckBox("Show separators between multifile test data parts", state.multifilePartsSeparator).apply {
+            addChangeListener {
+                state.multifilePartsSeparator = isSelected
+            }
+        }
+    }
+
     override fun createPanel(): DialogPanel {
         fun Panel.panelRow(title: String, panel: PanelWithButtons) {
             row(title) {}
@@ -256,6 +282,9 @@ class TestDataPathsConfigurable(private val project: Project) :
             panelRow("Related file search paths:", relatedFilesSearchPathsPanel)
             panelRow("Test tags:", testTagsPanel)
             panelRow("Ignored injected languages:", ignoredLanguagesForInjectionPanel)
+            row {
+                cell(multifilePartsSeparatorCheckbox)
+            }
         }
     }
 
@@ -294,12 +323,17 @@ class TestDataPathsConfigurable(private val project: Project) :
             .any { it.first != it.second }
     }
 
+    private fun multifilePartsSeparatorModified(): Boolean {
+        return configuration.multifilePartsSeparator != multifilePartsSeparator
+    }
+
     override fun isModified(): Boolean {
         return testDataModified(isFiles = true) ||
             testDataModified(isFiles = false) ||
             relatedFilesSearchPathsModified() ||
             testTagsModified() ||
-            ignoredLanguagesForInjectionModified()
+            ignoredLanguagesForInjectionModified() ||
+            multifilePartsSeparatorModified()
     }
 
     override fun reset() {
@@ -309,6 +343,8 @@ class TestDataPathsConfigurable(private val project: Project) :
         relatedFileSearchPaths = resetRelatedFileSearchPaths()
         testTags = resetTestTags()
         ignoredLanguagesForInjection = resetIgnoredLanguagesForInjection()
+        multifilePartsSeparator = resetMultifilePartsSeparator()
+        multifilePartsSeparatorCheckbox.isSelected = multifilePartsSeparator
         (testDataFilesPathPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
         (testDataDirectoriesPathPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
         (relatedFilesSearchPathsPanel.myTable.model as? AbstractTableModel)?.fireTableDataChanged()
@@ -318,6 +354,13 @@ class TestDataPathsConfigurable(private val project: Project) :
 
     override fun apply() {
         super.apply()
-        configuration.loadState(testDataFiles, testDataDirectories, relatedFileSearchPaths, testTags, ignoredLanguagesForInjection)
+        configuration.loadState(
+            testDataFiles,
+            testDataDirectories,
+            relatedFileSearchPaths,
+            testTags,
+            ignoredLanguagesForInjection,
+            multifilePartsSeparator,
+        )
     }
 }

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataLineMarkerProvider.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataLineMarkerProvider.kt
@@ -1,10 +1,13 @@
 package org.jetbrains.kotlin.test.helper.codeinsight
 
-import com.intellij.codeInsight.daemon.*
-import com.intellij.openapi.editor.colors.*
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.codeInsight.daemon.LineMarkerProvider
+import com.intellij.openapi.editor.colors.CodeInsightColors
+import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.markup.SeparatorPlacement
 import com.intellij.openapi.project.DumbAware
 import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.test.helper.TestDataPathsConfiguration
 import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataEntry
 
 /**
@@ -15,7 +18,7 @@ internal class MultifileTestDataLineMarkerProvider: LineMarkerProvider, DumbAwar
 
     override fun getLineMarkerInfo(element: PsiElement): LineMarkerInfo<*>? {
         val entry = element as? MultifileTestDataEntry ?: return null
-        if (!DaemonCodeAnalyzerSettings.getInstance().SHOW_METHOD_SEPARATORS) return null
+        if (!TestDataPathsConfiguration.getInstance(entry.project).multifilePartsSeparator) return null
 
         val globalScheme = EditorColorsManager.getInstance().globalScheme
         val anchor = entry.moduleHeader ?: entry.fileHeader ?: return null

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataMultiHostInjector.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataMultiHostInjector.kt
@@ -1,23 +1,22 @@
 package org.jetbrains.kotlin.test.helper.codeinsight
 
-import com.intellij.lang.Language
-import com.intellij.lang.injection.*
-import com.intellij.lang.java.JavaLanguage
+import com.intellij.lang.injection.MultiHostInjector
+import com.intellij.lang.injection.MultiHostRegistrar
 import com.intellij.openapi.util.TextRange
-import com.intellij.psi.*
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiLanguageInjectionHost
 import com.intellij.psi.impl.source.tree.PsiCommentImpl
 import org.jetbrains.annotations.Unmodifiable
 import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.test.helper.TestDataPathsConfiguration
 import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataFileContent
 import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataTextBlock
+import org.jetbrains.kotlin.util.capitalizeDecapitalize.toLowerCaseAsciiOnly
 
 class MultifileTestDataMultiHostInjector: MultiHostInjector {
     private val supportedElementTypes: List<Class<out PsiElement>> =
-        listOf(MultifileTestDataFileContent::class.java, PsiCommentImpl::class.java)
-
-    private val ignoredLanguagesForInjection: Set<Language> =
-        setOf(KotlinLanguage.INSTANCE, JavaLanguage.INSTANCE)
+        listOf(MultifileTestDataFileContent::class.java, PsiComment::class.java, MultifileTestDataTextBlock::class.java)
 
     override fun getLanguagesToInject(
         registrar: MultiHostRegistrar,
@@ -35,7 +34,11 @@ class MultifileTestDataMultiHostInjector: MultiHostInjector {
         } ?: return
 
         if (textBlock.fileContent != null) {
-            if (language in ignoredLanguagesForInjection) {
+            val ignoredLanguageIds =
+                TestDataPathsConfiguration.getInstance(context.project)
+                    .ignoredLanguagesForInjection
+                    .mapTo(hashSetOf(), String::toLowerCaseAsciiOnly)
+            if (language.id.toLowerCaseAsciiOnly() in ignoredLanguageIds) {
                 return
             }
         }

--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataMultiHostInjector.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataMultiHostInjector.kt
@@ -4,17 +4,17 @@ import com.intellij.lang.Language
 import com.intellij.lang.injection.*
 import com.intellij.lang.java.JavaLanguage
 import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.*
+import com.intellij.psi.impl.source.tree.PsiCommentImpl
 import org.jetbrains.annotations.Unmodifiable
 import org.jetbrains.kotlin.idea.KotlinLanguage
-import org.jetbrains.kotlin.test.helper.lang.*
-import java.util.regex.Pattern
+import org.jetbrains.kotlin.test.helper.TestDataPathsConfiguration
+import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataFileContent
+import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataTextBlock
 
 class MultifileTestDataMultiHostInjector: MultiHostInjector {
-    private val pattern = Pattern.compile("(//.*)\\R")
     private val supportedElementTypes: List<Class<out PsiElement>> =
-        listOf(MultifileTestDataFileContent::class.java, MultifileTestDataPreamble::class.java)
+        listOf(MultifileTestDataFileContent::class.java, PsiCommentImpl::class.java)
 
     private val ignoredLanguagesForInjection: Set<Language> =
         setOf(KotlinLanguage.INSTANCE, JavaLanguage.INSTANCE)
@@ -23,22 +23,25 @@ class MultifileTestDataMultiHostInjector: MultiHostInjector {
         registrar: MultiHostRegistrar,
         context: PsiElement
     ) {
-        if (context is MultifileTestDataPreamble) {
+        if (context is PsiCommentImpl) {
             injectCommentsAsKotlin(registrar, context)
-            return
         }
 
-        val content =
-            (context as? MultifileTestDataFileContent)?.takeIf { it.textLength != 0 } ?: return
-        val language = content.entry?.fileHeader?.injectedLanguage ?: return
+        val textBlock = (context as? MultifileTestDataTextBlock)?.takeIf { it.textLength != 0 } ?: return
+        val language = when {
+            textBlock.fileContent != null -> textBlock.fileContent?.entry?.fileHeader?.injectedLanguage
+            textBlock.preamble != null -> KotlinLanguage.INSTANCE
+            else -> null
+        } ?: return
 
-        if (language in ignoredLanguagesForInjection) {
-            injectCommentsAsKotlin(registrar, context)
-            return
+        if (textBlock.fileContent != null) {
+            if (language in ignoredLanguagesForInjection) {
+                return
+            }
         }
 
         registrar.startInjecting(language)
-        registrar.addPlace(null, null, content, TextRange(0, content.textLength))
+        registrar.addPlace(null, null, textBlock, TextRange(0, textBlock.textLength))
         registrar.doneInjecting()
     }
 
@@ -46,14 +49,11 @@ class MultifileTestDataMultiHostInjector: MultiHostInjector {
         registrar: MultiHostRegistrar,
         context: PsiLanguageInjectionHost
     ) {
-        val fileContent = context.text ?: return
-        val matcher = pattern.matcher(fileContent)
-        while (matcher.find()) {
-            registrar.startInjecting(KotlinLanguage.INSTANCE)
-            val textRange = TextRange(matcher.start(1), matcher.end(1))
-            registrar.addPlace(null, null, context, textRange)
-            registrar.doneInjecting()
-        }
+        val content = context.text.takeUnless { it.isEmpty() } ?: return
+        registrar.startInjecting(KotlinLanguage.INSTANCE)
+        val textRange = TextRange(0, content.length)
+        registrar.addPlace(null, null, context, textRange)
+        registrar.doneInjecting()
     }
 
     override fun elementsToInjectIn(): @Unmodifiable List<Class<out PsiElement>> =

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataElementTypes.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataElementTypes.kt
@@ -1,26 +1,39 @@
 package org.jetbrains.kotlin.test.helper.lang
 
-import com.intellij.psi.TokenType
+import com.intellij.psi.impl.source.tree.LeafElement
+import com.intellij.psi.impl.source.tree.PsiCommentImpl
+import com.intellij.psi.impl.source.tree.PsiWhiteSpaceImpl
+import com.intellij.psi.tree.ILeafElementType
 import com.intellij.psi.tree.IElementType
 import com.intellij.psi.tree.IFileElementType
 import com.intellij.psi.tree.TokenSet
 
 internal class MultifileTestDataTokenType(debugName: String) : IElementType(debugName, MultifileTestDataLanguage)
 
+internal class MultifileTestDataCommentTokenType(debugName: String) : IElementType(debugName, MultifileTestDataLanguage), ILeafElementType {
+    override fun createLeafNode(leafText: CharSequence): LeafElement = PsiCommentImpl(this, leafText)
+}
+
+internal class MultifileTestDataWhiteSpaceTokenType(debugName: String) : IElementType(debugName, MultifileTestDataLanguage), ILeafElementType {
+    override fun createLeafNode(leafText: CharSequence): LeafElement = PsiWhiteSpaceImpl(leafText)
+}
+
 internal class MultifileTestDataElementType(debugName: String) : IElementType(debugName, MultifileTestDataLanguage)
 
 internal val MULTIFILE_TEXT_FILE: IFileElementType = IFileElementType(MultifileTestDataLanguage)
 
-internal val MULTIFILE_PREAMBLE_TEXT = MultifileTestDataTokenType("MULTIFILE_PREAMBLE_TEXT")
-internal val MULTIFILE_MODULE_LINE = MultifileTestDataTokenType("MULTIFILE_MODULE_LINE")
-internal val MULTIFILE_FILE_LINE = MultifileTestDataTokenType("MULTIFILE_FILE_LINE")
-internal val MULTIFILE_CONTENT_TEXT = MultifileTestDataTokenType("MULTIFILE_CONTENT_TEXT")
+internal val MULTIFILE_COMMENT_LINE = MultifileTestDataCommentTokenType("MULTIFILE_COMMENT_LINE")
+internal val MULTIFILE_MODULE_LINE = MultifileTestDataCommentTokenType("MULTIFILE_MODULE_LINE")
+internal val MULTIFILE_FILE_LINE = MultifileTestDataCommentTokenType("MULTIFILE_FILE_LINE")
+internal val MULTIFILE_TEXT_BLOCK = MultifileTestDataTokenType("MULTIFILE_TEXT_BLOCK")
+internal val MULTIFILE_NEW_LINE = MultifileTestDataWhiteSpaceTokenType("MULTIFILE_NEW_LINE")
 
 internal val MULTIFILE_PREAMBLE = MultifileTestDataElementType("MULTIFILE_PREAMBLE")
 internal val MULTIFILE_ENTRY = MultifileTestDataElementType("MULTIFILE_ENTRY")
 internal val MULTIFILE_MODULE_HEADER = MultifileTestDataElementType("MULTIFILE_MODULE_HEADER")
 internal val MULTIFILE_FILE_HEADER = MultifileTestDataElementType("MULTIFILE_FILE_HEADER")
 internal val MULTIFILE_FILE_CONTENT = MultifileTestDataElementType("MULTIFILE_FILE_CONTENT")
+internal val MULTIFILE_TEXT_BLOCK_ELEMENT = MultifileTestDataElementType("MULTIFILE_TEXT_BLOCK_ELEMENT")
 
-internal val MULTIFILE_WHITE_SPACES: TokenSet = TokenSet.create(TokenType.WHITE_SPACE)
+internal val MULTIFILE_WHITE_SPACES: TokenSet = TokenSet.EMPTY
 internal val MULTIFILE_COMMENT_TOKENS: TokenSet = TokenSet.EMPTY

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexer.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexer.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.kotlin.test.helper.lang
 
 import com.intellij.lexer.LexerBase
-import com.intellij.psi.TokenType
 import com.intellij.psi.tree.IElementType
 
 class MultifileTestDataLexer : LexerBase() {
@@ -62,23 +61,18 @@ class MultifileTestDataLexer : LexerBase() {
         when {
             isStructuralModuleHeaderAt(tokenStart) -> setToken(MULTIFILE_MODULE_LINE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
             isFileHeaderAt(tokenStart) -> setToken(MULTIFILE_FILE_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
-            else -> {
-                tokenType = MULTIFILE_PREAMBLE_TEXT
-                tokenEnd = nextBoundaryOffset(tokenStart)
-                state = BEFORE_FIRST_ENTRY
-            }
+            isBlankLine(tokenStart) -> setToken(MULTIFILE_NEW_LINE, lineEnd(tokenStart), BEFORE_FIRST_ENTRY)
+            isCommentLine(tokenStart) -> setToken(MULTIFILE_COMMENT_LINE, lineEnd(tokenStart), BEFORE_FIRST_ENTRY)
+            else -> setToken(MULTIFILE_TEXT_BLOCK, nextTextBlockEnd(tokenStart), BEFORE_FIRST_ENTRY)
         }
     }
 
     private fun locateAfterModuleHeader() {
         when {
-            isWhitespaceLine(tokenStart) -> setToken(TokenType.WHITE_SPACE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
+            isBlankLine(tokenStart) -> setToken(MULTIFILE_NEW_LINE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
             isFileHeaderAt(tokenStart) -> setToken(MULTIFILE_FILE_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
-            else -> {
-                tokenType = MULTIFILE_CONTENT_TEXT
-                tokenEnd = nextBoundaryOffset(tokenStart)
-                state = AFTER_FILE_HEADER
-            }
+            isCommentLine(tokenStart) -> setToken(MULTIFILE_COMMENT_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
+            else -> setToken(MULTIFILE_TEXT_BLOCK, nextTextBlockEnd(tokenStart), AFTER_FILE_HEADER)
         }
     }
 
@@ -86,11 +80,9 @@ class MultifileTestDataLexer : LexerBase() {
         when {
             isStructuralModuleHeaderAt(tokenStart) -> setToken(MULTIFILE_MODULE_LINE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
             isFileHeaderAt(tokenStart) -> setToken(MULTIFILE_FILE_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
-            else -> {
-                tokenType = MULTIFILE_CONTENT_TEXT
-                tokenEnd = nextBoundaryOffset(tokenStart)
-                state = AFTER_FILE_HEADER
-            }
+            isBlankLine(tokenStart) -> setToken(MULTIFILE_NEW_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
+            isCommentLine(tokenStart) -> setToken(MULTIFILE_COMMENT_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
+            else -> setToken(MULTIFILE_TEXT_BLOCK, nextTextBlockEnd(tokenStart), AFTER_FILE_HEADER)
         }
     }
 
@@ -104,10 +96,23 @@ class MultifileTestDataLexer : LexerBase() {
         state = newState
     }
 
-    private fun nextBoundaryOffset(offset: Int): Int {
+    private fun isStructuralModuleHeaderAt(offset: Int): Boolean {
+        if (!isDirectiveLine(offset, "MODULE")) {
+            return false
+        }
+
+        var nextOffset = lineEnd(offset)
+        while (nextOffset < endOffset && isBlankLine(nextOffset)) {
+            nextOffset = lineEnd(nextOffset)
+        }
+
+        return nextOffset < endOffset && isFileHeaderAt(nextOffset)
+    }
+
+    private fun nextTextBlockEnd(offset: Int): Int {
         var cursor = offset
         while (cursor < endOffset) {
-            if (isFileHeaderAt(cursor) || isStructuralModuleHeaderAt(cursor)) {
+            if (isStructuralModuleHeaderAt(cursor) || isFileHeaderAt(cursor)) {
                 return cursor
             }
             cursor = lineEnd(cursor)
@@ -115,20 +120,10 @@ class MultifileTestDataLexer : LexerBase() {
         return endOffset
     }
 
-    private fun isStructuralModuleHeaderAt(offset: Int): Boolean {
-        if (!isDirectiveLine(offset, "MODULE")) {
-            return false
-        }
-
-        var nextOffset = lineEnd(offset)
-        while (nextOffset < endOffset && isWhitespaceLine(nextOffset)) {
-            nextOffset = lineEnd(nextOffset)
-        }
-
-        return nextOffset < endOffset && isFileHeaderAt(nextOffset)
-    }
-
     private fun isFileHeaderAt(offset: Int): Boolean = isDirectiveLine(offset, "FILE")
+
+    private fun isCommentLine(offset: Int): Boolean =
+        startsWithDoubleSlash(offset) && !isFileHeaderAt(offset) && !isStructuralModuleHeaderAt(offset)
 
     private fun isDirectiveLine(
         offset: Int,
@@ -157,7 +152,10 @@ class MultifileTestDataLexer : LexerBase() {
         return cursor + directivePrefix.length <= lineEndWithoutSeparator(offset)
     }
 
-    private fun isWhitespaceLine(offset: Int): Boolean {
+    private fun startsWithDoubleSlash(offset: Int): Boolean =
+        offset + 1 < endOffset && buffer[offset] == '/' && buffer[offset + 1] == '/'
+
+    private fun isBlankLine(offset: Int): Boolean {
         val end = lineEndWithoutSeparator(offset)
         for (index in offset until end) {
             if (!buffer[index].isWhitespace()) {

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexer.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexer.kt
@@ -59,7 +59,7 @@ class MultifileTestDataLexer : LexerBase() {
 
     private fun locateBeforeFirstEntry() {
         when {
-            isStructuralModuleHeaderAt(tokenStart) -> setToken(MULTIFILE_MODULE_LINE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
+            isModuleHeaderAt(tokenStart) -> setToken(MULTIFILE_MODULE_LINE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
             isFileHeaderAt(tokenStart) -> setToken(MULTIFILE_FILE_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
             isBlankLine(tokenStart) -> setToken(MULTIFILE_NEW_LINE, lineEnd(tokenStart), BEFORE_FIRST_ENTRY)
             isCommentLine(tokenStart) -> setToken(MULTIFILE_COMMENT_LINE, lineEnd(tokenStart), BEFORE_FIRST_ENTRY)
@@ -78,7 +78,7 @@ class MultifileTestDataLexer : LexerBase() {
 
     private fun locateAfterFileHeader() {
         when {
-            isStructuralModuleHeaderAt(tokenStart) -> setToken(MULTIFILE_MODULE_LINE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
+            isModuleHeaderAt(tokenStart) -> setToken(MULTIFILE_MODULE_LINE, lineEnd(tokenStart), AFTER_MODULE_HEADER)
             isFileHeaderAt(tokenStart) -> setToken(MULTIFILE_FILE_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
             isBlankLine(tokenStart) -> setToken(MULTIFILE_NEW_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
             isCommentLine(tokenStart) -> setToken(MULTIFILE_COMMENT_LINE, lineEnd(tokenStart), AFTER_FILE_HEADER)
@@ -96,23 +96,12 @@ class MultifileTestDataLexer : LexerBase() {
         state = newState
     }
 
-    private fun isStructuralModuleHeaderAt(offset: Int): Boolean {
-        if (!isDirectiveLine(offset, "MODULE")) {
-            return false
-        }
-
-        var nextOffset = lineEnd(offset)
-        while (nextOffset < endOffset && isBlankLine(nextOffset)) {
-            nextOffset = lineEnd(nextOffset)
-        }
-
-        return nextOffset < endOffset && isFileHeaderAt(nextOffset)
-    }
+    private fun isModuleHeaderAt(offset: Int): Boolean = isDirectiveLine(offset, "MODULE")
 
     private fun nextTextBlockEnd(offset: Int): Int {
         var cursor = offset
         while (cursor < endOffset) {
-            if (isStructuralModuleHeaderAt(cursor) || isFileHeaderAt(cursor)) {
+            if (isModuleHeaderAt(cursor) || isFileHeaderAt(cursor)) {
                 return cursor
             }
             cursor = lineEnd(cursor)
@@ -123,7 +112,7 @@ class MultifileTestDataLexer : LexerBase() {
     private fun isFileHeaderAt(offset: Int): Boolean = isDirectiveLine(offset, "FILE")
 
     private fun isCommentLine(offset: Int): Boolean =
-        startsWithDoubleSlash(offset) && !isFileHeaderAt(offset) && !isStructuralModuleHeaderAt(offset)
+        startsWithDoubleSlash(offset) && !isFileHeaderAt(offset) && !isModuleHeaderAt(offset)
 
     private fun isDirectiveLine(
         offset: Int,

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataParser.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataParser.kt
@@ -27,11 +27,9 @@ class MultifileTestDataParser : PsiParser {
     }
 
     private fun parsePreamble(builder: PsiBuilder) {
-        if (builder.tokenType == MULTIFILE_PREAMBLE_TEXT) {
+        if (builder.tokenType != null && builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
             val preamble = builder.mark()
-            while (builder.tokenType == MULTIFILE_PREAMBLE_TEXT) {
-                builder.advanceLexer()
-            }
+            parseBlockBody(builder)
             preamble.done(MULTIFILE_PREAMBLE)
         }
     }
@@ -47,6 +45,10 @@ class MultifileTestDataParser : PsiParser {
             val moduleHeader = builder.mark()
             builder.advanceLexer()
             moduleHeader.done(MULTIFILE_MODULE_HEADER)
+
+            while (builder.tokenType == MULTIFILE_NEW_LINE) {
+                builder.advanceLexer()
+            }
         }
 
         if (builder.tokenType == MULTIFILE_FILE_LINE) {
@@ -61,13 +63,23 @@ class MultifileTestDataParser : PsiParser {
 
         if (builder.tokenType != null && builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
             val content = builder.mark()
-            while (builder.tokenType != null && builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
-                builder.advanceLexer()
-            }
+            parseBlockBody(builder)
             content.done(MULTIFILE_FILE_CONTENT)
         }
 
         entry.done(MULTIFILE_ENTRY)
         return true
+    }
+
+    private fun parseBlockBody(builder: PsiBuilder) {
+        while (builder.tokenType != null && builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
+            if (builder.tokenType == MULTIFILE_TEXT_BLOCK) {
+                val textBlock = builder.mark()
+                builder.advanceLexer()
+                textBlock.done(MULTIFILE_TEXT_BLOCK_ELEMENT)
+                continue
+            }
+            builder.advanceLexer()
+        }
     }
 }

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataParser.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataParser.kt
@@ -11,11 +11,12 @@ class MultifileTestDataParser : PsiParser {
         builder: PsiBuilder,
     ): ASTNode {
         val rootMarker = builder.mark()
+        val hasStructuralDirectives = hasStructuralDirectives(builder.originalText)
 
-        parsePreamble(builder)
+        parsePreamble(builder, hasStructuralDirectives)
 
         while (!builder.eof()) {
-            if (!parseEntry(builder)) {
+            if (!parseEntry(builder, hasStructuralDirectives)) {
                 val invalid = builder.mark()
                 builder.advanceLexer()
                 invalid.error("Unexpected multifile test data token")
@@ -26,15 +27,39 @@ class MultifileTestDataParser : PsiParser {
         return builder.treeBuilt
     }
 
-    private fun parsePreamble(builder: PsiBuilder) {
-        if (builder.tokenType != null && builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
+    private fun parsePreamble(
+        builder: PsiBuilder,
+        hasStructuralDirectives: Boolean,
+    ) {
+        if (hasStructuralDirectives && builder.tokenType != null && builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
             val preamble = builder.mark()
             parseBlockBody(builder)
+            preamble.done(MULTIFILE_PREAMBLE)
+            return
+        }
+
+        if (!hasStructuralDirectives && (builder.tokenType == MULTIFILE_NEW_LINE || builder.tokenType == MULTIFILE_COMMENT_LINE)) {
+            val preamble = builder.mark()
+            while (builder.tokenType == MULTIFILE_NEW_LINE || builder.tokenType == MULTIFILE_COMMENT_LINE) {
+                builder.advanceLexer()
+            }
             preamble.done(MULTIFILE_PREAMBLE)
         }
     }
 
-    private fun parseEntry(builder: PsiBuilder): Boolean {
+    private fun parseEntry(
+        builder: PsiBuilder,
+        hasStructuralDirectives: Boolean,
+    ): Boolean {
+        if (!hasStructuralDirectives) {
+            val entry = builder.mark()
+            val content = builder.mark()
+            parseBlockBody(builder)
+            content.done(MULTIFILE_FILE_CONTENT)
+            entry.done(MULTIFILE_ENTRY)
+            return true
+        }
+
         if (builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
             return false
         }
@@ -55,10 +80,6 @@ class MultifileTestDataParser : PsiParser {
             val fileHeader = builder.mark()
             builder.advanceLexer()
             fileHeader.done(MULTIFILE_FILE_HEADER)
-        } else {
-            builder.error("Expected // FILE: directive")
-            entry.done(MULTIFILE_ENTRY)
-            return true
         }
 
         if (builder.tokenType != null && builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
@@ -71,6 +92,10 @@ class MultifileTestDataParser : PsiParser {
         return true
     }
 
+    private fun hasStructuralDirectives(text: CharSequence): Boolean {
+        return text.lineSequence().any { it.contains(STRUCTURAL_DIRECTIVE_REGEX) }
+    }
+
     private fun parseBlockBody(builder: PsiBuilder) {
         while (builder.tokenType != null && builder.tokenType != MULTIFILE_MODULE_LINE && builder.tokenType != MULTIFILE_FILE_LINE) {
             if (builder.tokenType == MULTIFILE_TEXT_BLOCK) {
@@ -81,5 +106,9 @@ class MultifileTestDataParser : PsiParser {
             }
             builder.advanceLexer()
         }
+    }
+
+    companion object {
+        private val STRUCTURAL_DIRECTIVE_REGEX = """^//\s*(?:FILE|MODULE)""".toRegex()
     }
 }

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataParserDefinition.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataParserDefinition.kt
@@ -33,6 +33,7 @@ class MultifileTestDataParserDefinition : ParserDefinition {
             MULTIFILE_MODULE_HEADER -> MultifileTestDataModuleHeader(node)
             MULTIFILE_FILE_HEADER -> MultifileTestDataFileHeader(node)
             MULTIFILE_FILE_CONTENT -> MultifileTestDataFileContent(node)
+            MULTIFILE_TEXT_BLOCK_ELEMENT -> MultifileTestDataTextBlock(node)
             else -> ASTWrapperPsiElement(node)
         }
 

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataPsi.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataPsi.kt
@@ -99,3 +99,11 @@ internal class MultifileTestDataFileContent(node: ASTNode) : InjectableLanguageI
     val entry: MultifileTestDataEntry?
         get() = parent as? MultifileTestDataEntry
 }
+
+internal class MultifileTestDataTextBlock(node: ASTNode) : InjectableLanguageInjectionHost(node) {
+    val fileContent: MultifileTestDataFileContent?
+        get() = parent as? MultifileTestDataFileContent
+
+    val preamble: MultifileTestDataPreamble?
+        get() = parent as? MultifileTestDataPreamble
+}

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataTextFileImpl.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataTextFileImpl.kt
@@ -15,16 +15,16 @@ import com.intellij.psi.util.PsiTreeUtil
  * Root PSI file for Kotlin multifile test data.
  *
  * Structure:
- * - optional [MultifileTestDataPreamble] containing top-level comments, blank lines, or plain text
+ * - optional [MultifileTestDataPreamble] containing top-level comments and blank lines
  * - zero or more [MultifileTestDataEntry] blocks
  *
  * Each [MultifileTestDataEntry] contains:
  * - optional [MultifileTestDataModuleHeader]
- * - required [MultifileTestDataFileHeader]
+ * - optional [MultifileTestDataFileHeader] (required for explicit multifile entries)
  * - optional [MultifileTestDataFileContent]
  *
- * The top-level preamble is intentionally shaped like a content block so files without any `// FILE:`
- * separators can still be represented as a single Kotlin-like text body.
+ * When no `// FILE:` or structural `// MODULE:` directives are present, the parser creates
+ * one implicit [MultifileTestDataEntry] from the non-comment body after the preamble.
  */
 class MultifileTestDataTextFileImpl(viewProvider: FileViewProvider) :
     PsiFileImpl(MULTIFILE_TEXT_FILE, MULTIFILE_TEXT_FILE, viewProvider),

--- a/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataTextFileImpl.kt
+++ b/src/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataTextFileImpl.kt
@@ -11,6 +11,21 @@ import com.intellij.psi.impl.source.PsiFileImpl
 import com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry
 import com.intellij.psi.util.PsiTreeUtil
 
+/**
+ * Root PSI file for Kotlin multifile test data.
+ *
+ * Structure:
+ * - optional [MultifileTestDataPreamble] containing top-level comments, blank lines, or plain text
+ * - zero or more [MultifileTestDataEntry] blocks
+ *
+ * Each [MultifileTestDataEntry] contains:
+ * - optional [MultifileTestDataModuleHeader]
+ * - required [MultifileTestDataFileHeader]
+ * - optional [MultifileTestDataFileContent]
+ *
+ * The top-level preamble is intentionally shaped like a content block so files without any `// FILE:`
+ * separators can still be represented as a single Kotlin-like text body.
+ */
 class MultifileTestDataTextFileImpl(viewProvider: FileViewProvider) :
     PsiFileImpl(MULTIFILE_TEXT_FILE, MULTIFILE_TEXT_FILE, viewProvider),
     PsiPlainTextFile,

--- a/src/org/jetbrains/kotlin/test/helper/reference/TestDirectiveReference.kt
+++ b/src/org/jetbrains/kotlin/test/helper/reference/TestDirectiveReference.kt
@@ -14,9 +14,7 @@ import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtDeclarationWithReturnType
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
-
-private val DIRECTIVE_CLASS_ID =
-    ClassId.topLevel(FqName("org.jetbrains.kotlin.test.directives.model.Directive"))
+import org.jetbrains.kotlin.test.helper.TestDataPathsConfiguration
 
 class TestDirectiveReference(
     element: PsiElement,
@@ -26,8 +24,8 @@ class TestDirectiveReference(
 
     override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
         val project = myElement.project
-        return resolvePreferringProjectScope(project) {
-            val declarations = KotlinPropertyShortNameIndex.Helper[key, project, it]
+        return resolvePreferringProjectScope(project) { scope ->
+            val declarations = KotlinPropertyShortNameIndex.Helper[key, project, scope]
             declarations.filter { it.isDirective() }
         }.map { PsiElementResolveResult(it) }
             .toTypedArray()
@@ -41,11 +39,18 @@ class TestDirectiveReference(
 }
 
 fun KtNamedDeclaration.isDirective(): Boolean {
-    if (this !is KtDeclarationWithReturnType) return false
-    return analyze(this) {
-        returnType.isSubtypeOf(DIRECTIVE_CLASS_ID)
+    val directiveClassId = TestDataPathsConfiguration.getInstance(project).directiveClassId
+        .takeIf(String::isNotBlank)
+        ?.let(::runCatchingClassId)
+        ?: return false
+
+    return this is KtDeclarationWithReturnType && analyze(this) {
+        returnType.isSubtypeOf(directiveClassId)
     }
 }
+
+private fun runCatchingClassId(fqName: String): ClassId? =
+    runCatching { ClassId.topLevel(FqName(fqName)) }.getOrNull()
 
 fun <T : PsiElement> resolvePreferringProjectScope(project: Project, resolve: (GlobalSearchScope) -> List<T>): List<T> {
     return resolve(GlobalSearchScope.projectScope(project))

--- a/src/org/jetbrains/kotlin/test/helper/ui/settings/IgnoredLanguagesForInjectionPanel.kt
+++ b/src/org/jetbrains/kotlin/test/helper/ui/settings/IgnoredLanguagesForInjectionPanel.kt
@@ -1,0 +1,71 @@
+package org.jetbrains.kotlin.test.helper.ui.settings
+
+import com.intellij.ui.ToolbarDecorator
+import com.intellij.ui.table.JBTable
+import org.jetbrains.kotlin.test.helper.PluginSettingsState
+import javax.swing.DefaultCellEditor
+import javax.swing.JComponent
+import javax.swing.table.DefaultTableCellRenderer
+import javax.swing.table.TableModel
+
+class IgnoredLanguagesForInjectionPanel(private val state: PluginSettingsState) : AbstractSettingsPanel<String>() {
+    private val ignoredLanguagesForInjection: MutableList<String>
+        get() = state.ignoredLanguagesForInjection
+
+    override val numberOfElements: Int
+        get() = ignoredLanguagesForInjection.size
+
+    override fun addElement(index: Int, element: String) {
+        ignoredLanguagesForInjection.add(index, element)
+    }
+
+    override fun removeElementAt(index: Int) {
+        ignoredLanguagesForInjection.removeAt(index)
+    }
+
+    override fun isElementExcluded(element: String): Boolean = false
+
+    override fun createNewElementsOnAddClick(): List<String> = listOf("")
+
+    override fun createMainComponent(): JComponent {
+        val names = arrayOf("Language ID")
+        val dataModel: TableModel = object : javax.swing.table.AbstractTableModel() {
+            override fun getRowCount(): Int = ignoredLanguagesForInjection.size
+
+            override fun getColumnCount(): Int = names.size
+
+            override fun getColumnName(column: Int): String = names[column]
+
+            override fun getColumnClass(columnIndex: Int): Class<*> = String::class.java
+
+            override fun isCellEditable(rowIndex: Int, columnIndex: Int): Boolean = true
+
+            override fun getValueAt(rowIndex: Int, columnIndex: Int): Any = ignoredLanguagesForInjection[rowIndex]
+
+            override fun setValueAt(aValue: Any, rowIndex: Int, columnIndex: Int) {
+                if (aValue !is String) return
+                ignoredLanguagesForInjection[rowIndex] = aValue
+            }
+        }
+
+        myTable = JBTable(dataModel).apply {
+            configure(names, DefaultTableCellRenderer())
+        }
+
+        val defaultEditor = myTable.getDefaultEditor(String::class.java)
+        if (defaultEditor is DefaultCellEditor) {
+            defaultEditor.clickCountToStart = 1
+        }
+
+        return ToolbarDecorator.createDecorator(myTable)
+            .disableUpAction()
+            .disableDownAction()
+            .setAddAction { onAddClick() }
+            .setRemoveAction { onRemoveClick() }
+            .createPanel()
+    }
+
+    init {
+        initPanel()
+    }
+}

--- a/test/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexerTest.kt
+++ b/test/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexerTest.kt
@@ -8,12 +8,14 @@ class MultifileTestDataLexerTest {
     fun `keeps preamble before first file and parses subsequent entries`() {
         assertEquals(
             listOf(
-                "MULTIFILE_PREAMBLE_TEXT:// FIR_IDENTICAL\\n// SKIP_TXT\\n\\n",
+                "MULTIFILE_COMMENT_LINE:// FIR_IDENTICAL\\n",
+                "MULTIFILE_COMMENT_LINE:// SKIP_TXT\\n",
+                "MULTIFILE_NEW_LINE:\\n",
                 "MULTIFILE_MODULE_LINE:// MODULE: moduleA\\n",
                 "MULTIFILE_FILE_LINE:// FILE: a.kt\\n",
-                "MULTIFILE_CONTENT_TEXT:package sample\\n\\nclass A\\n",
+                "MULTIFILE_TEXT_BLOCK:package sample\\n\\nclass A\\n",
                 "MULTIFILE_FILE_LINE:// FILE: b.java\\n",
-                "MULTIFILE_CONTENT_TEXT:class B {}",
+                "MULTIFILE_TEXT_BLOCK:class B {}",
             ),
             tokenize(
                 """
@@ -33,11 +35,71 @@ class MultifileTestDataLexerTest {
     }
 
     @Test
+    fun `treats non comment text before first file as content not preamble`() {
+        assertEquals(
+            listOf(
+                "MULTIFILE_TEXT_BLOCK:package stray\\n",
+                "MULTIFILE_FILE_LINE:// FILE: sample.kt\\n",
+                "MULTIFILE_TEXT_BLOCK:class A",
+            ),
+            tokenize(
+                """
+                package stray
+                // FILE: sample.kt
+                class A
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `unsplit file may live entirely in top level preamble block`() {
+        assertEquals(
+            listOf(
+                "MULTIFILE_COMMENT_LINE:// LANGUAGE: +ContextParameters\\n",
+                "MULTIFILE_NEW_LINE:\\n",
+                "MULTIFILE_TEXT_BLOCK:package sample\\n\\nclass A",
+            ),
+            tokenize(
+                """
+                // LANGUAGE: +ContextParameters
+                
+                package sample
+                
+                class A
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `content block may start with comment preamble before actual text`() {
+        assertEquals(
+            listOf(
+                "MULTIFILE_FILE_LINE:// FILE: sample.kt\\n",
+                "MULTIFILE_COMMENT_LINE:// LANGUAGE: +ContextParameters\\n",
+                "MULTIFILE_COMMENT_LINE:// WITH_STDLIB\\n",
+                "MULTIFILE_NEW_LINE:\\n",
+                "MULTIFILE_TEXT_BLOCK:class A",
+            ),
+            tokenize(
+                """
+                // FILE: sample.kt
+                // LANGUAGE: +ContextParameters
+                // WITH_STDLIB
+                
+                class A
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
     fun `does not split on indented file marker inside content`() {
         assertEquals(
             listOf(
                 "MULTIFILE_FILE_LINE:// FILE: sample.kt\\n",
-                "MULTIFILE_CONTENT_TEXT:fun example() {\\n    // FILE: not-a-header.kt\\n}",
+                "MULTIFILE_TEXT_BLOCK:fun example() {\\n    // FILE: not-a-header.kt\\n}",
             ),
             tokenize(
                 """
@@ -55,7 +117,7 @@ class MultifileTestDataLexerTest {
         assertEquals(
             listOf(
                 "MULTIFILE_FILE_LINE:// FILE: sample.kt\\n",
-                "MULTIFILE_CONTENT_TEXT:fun example() {\\n// MODULE: not-structural\\nprintln(42)\\n}",
+                "MULTIFILE_TEXT_BLOCK:fun example() {\\n// MODULE: not-structural\\nprintln(42)\\n}",
             ),
             tokenize(
                 """

--- a/test/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexerTest.kt
+++ b/test/org/jetbrains/kotlin/test/helper/lang/MultifileTestDataLexerTest.kt
@@ -113,11 +113,13 @@ class MultifileTestDataLexerTest {
     }
 
     @Test
-    fun `treats module header inside content as plain text when no file follows`() {
+    fun `splits on module header inside content when no file follows`() {
         assertEquals(
             listOf(
                 "MULTIFILE_FILE_LINE:// FILE: sample.kt\\n",
-                "MULTIFILE_TEXT_BLOCK:fun example() {\\n// MODULE: not-structural\\nprintln(42)\\n}",
+                "MULTIFILE_TEXT_BLOCK:fun example() {\\n",
+                "MULTIFILE_MODULE_LINE:// MODULE: not-structural\\n",
+                "MULTIFILE_TEXT_BLOCK:println(42)\\n}",
             ),
             tokenize(
                 """
@@ -126,6 +128,50 @@ class MultifileTestDataLexerTest {
                 // MODULE: not-structural
                 println(42)
                 }
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `splits module only entries without file directives`() {
+        assertEquals(
+            listOf(
+                "MULTIFILE_MODULE_LINE:// MODULE: x\\n",
+                "MULTIFILE_TEXT_BLOCK:aaa\\n\\n",
+                "MULTIFILE_MODULE_LINE:// MODULE: y\\n",
+                "MULTIFILE_TEXT_BLOCK:bbb",
+            ),
+            tokenize(
+                """
+                // MODULE: x
+                aaa
+                
+                // MODULE: y
+                bbb
+                """.trimIndent(),
+            ),
+        )
+    }
+
+    @Test
+    fun `supports module only and module plus file transitions`() {
+        assertEquals(
+            listOf(
+                "MULTIFILE_MODULE_LINE:// MODULE: x\\n",
+                "MULTIFILE_TEXT_BLOCK:aaa\\n\\n",
+                "MULTIFILE_MODULE_LINE:// MODULE: y\\n",
+                "MULTIFILE_FILE_LINE:// FILE: b.kt\\n",
+                "MULTIFILE_TEXT_BLOCK:bbb",
+            ),
+            tokenize(
+                """
+                // MODULE: x
+                aaa
+                
+                // MODULE: y
+                // FILE: b.kt
+                bbb
                 """.trimIndent(),
             ),
         )


### PR DESCRIPTION
- Improvements around PSI structure: explicitly handle comments, preamble could have content text without any file/module header
- Settings for ignored languages, defaults are `Kotlin` and `Java`. I'd like to have a clean one in IJ monorepo to force fixing injection error higlighting
- Settings for multifile parts separator. It just deserves its own
- Settings for directiveClassId for customization purposes in IJ monorepo
- Fixed some glitch of svg icon
<img width="357" height="127" alt="image" src="https://github.com/user-attachments/assets/3b7a559d-550f-42b6-ba5f-151ed6b6a31c" />
