### PR TITLE
Use new updateTestData task for Update Test Data actions

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -158,21 +158,21 @@
                     id="TestDataManagerUpdateAllTests"
                     class="org.jetbrains.kotlin.test.helper.actions.test.data.manager.TestDataManagerUpdateAction"
                     text="Update Test Data"
-                    description="Runs :manageTestDataGlobally with update mode for selected files"
+                    description="Updates test data for the selected files using :updateTestData when available, otherwise falls back to :manageTestDataGlobally with update mode"
                     icon="AllIcons.Diff.ApplyNotConflicts">
             </action>
             <action
                     id="TestDataManagerUpdateGoldenTests"
                     class="org.jetbrains.kotlin.test.helper.actions.test.data.manager.TestDataManagerUpdateGoldenAction"
                     text="Update Test Data (Golden Only)"
-                    description="Runs :manageTestDataGlobally with update mode for selected golden files"
+                    description="Updates only the golden test data for the selected files using :updateTestData when available, otherwise falls back to :manageTestDataGlobally with update mode"
                     icon="AllIcons.Diff.ApplyNotConflicts">
             </action>
             <action
                     id="TestDataManagerUpdateIncrementalAction"
                     class="org.jetbrains.kotlin.test.helper.actions.test.data.manager.TestDataManagerUpdateIncrementalAction"
                     text="Update Test Data (Incremental)"
-                    description="Runs :manageTestDataGlobally with update mode for selected files. Runs alternative tests only if the golden one had changes"
+                    description="Updates test data for the selected files; alternative tests run only if the golden one had changes. Uses :updateTestData when available, otherwise falls back to :manageTestDataGlobally with update mode"
                     icon="AllIcons.Diff.ApplyNotConflicts">
             </action>
             <action

--- a/src/org/jetbrains/kotlin/test/helper/actions/test/data/manager/TestDataManagerActionBase.kt
+++ b/src/org/jetbrains/kotlin/test/helper/actions/test/data/manager/TestDataManagerActionBase.kt
@@ -29,12 +29,15 @@ class TestDataManagerGroup : DefaultActionGroup() {
  */
 abstract class TestDataManagerActionBase : RunSelectedFilesActionBase() {
     protected fun runTestDataManager(project: Project, configure: TestDataManagerCommandBuilder.() -> Unit = {}) {
-        val builder = TestDataManagerCommandBuilder().apply(configure)
-        val command = builder.build()
+        val builder = TestDataManagerCommandBuilder().apply {
+            updateTestDataIsAvailable = project.hasUpdateTestDataTask
+            configure()
+        }
+
         runGradleCommandLine(
             project = project,
             config = GradleRunConfig(
-                commandLine = command,
+                commandLine = builder.build(),
                 title = builder.asTitle(),
                 debug = isDebug,
                 useProjectBasePath = true,
@@ -46,6 +49,9 @@ abstract class TestDataManagerActionBase : RunSelectedFilesActionBase() {
 
 val Project.hasManageTestDataGloballyTask: Boolean
     get() = hasGradleTask("manageTestDataGlobally")
+
+val Project.hasUpdateTestDataTask: Boolean
+    get() = hasGradleTask("updateTestData")
 
 /**
  * The list of selected test data paths for the action.

--- a/src/org/jetbrains/kotlin/test/helper/actions/test/data/manager/TestDataManagerCommandBuilder.kt
+++ b/src/org/jetbrains/kotlin/test/helper/actions/test/data/manager/TestDataManagerCommandBuilder.kt
@@ -6,7 +6,21 @@ enum class TestDataManagerMode(val cliValue: String) {
 }
 
 /**
- * Represents a command for the `manageTestDataGlobally` gradle task.
+ * Property prefix used by the `updateTestData` task to receive options.
+ *
+ * Defined in the Kotlin repo at `repo/gradle-build-conventions/test-data-manager-convention/src/main/kotlin/TestDataManagerConstants.kt`.
+ */
+private const val UPDATE_OPTIONS_PREFIX = "org.jetbrains.kotlin.testDataManager.options"
+
+/**
+ * Builds a Gradle command for either `manageTestDataGlobally` (the default) or `updateTestData`
+ * (when [updateTestDataIsAvailable] is `true` and [mode] is [TestDataManagerMode.UPDATE]).
+ *
+ * `updateTestData` is a configuration-cache-friendly alternative to
+ * `manageTestDataGlobally --mode=update`: its options are passed as `-P` Gradle properties read
+ * at execution time, so changing values between runs does not invalidate Gradle's configuration
+ * cache. The task only handles the update mode, so it is selected only for
+ * [TestDataManagerMode.UPDATE]; other modes always fall back to `manageTestDataGlobally`.
  *
  * See `repo/gradle-build-conventions/test-data-manager-convention` in the Kotlin repo for more details.
  */
@@ -17,24 +31,65 @@ class TestDataManagerCommandBuilder {
     var goldenOnly: Boolean? = null
     var incremental: Boolean? = false
 
-    fun build(): String = buildString {
-        append("manageTestDataGlobally")
-        mode?.let { append(" --mode=${it.cliValue}") }
-        if (testDataPaths.isNotEmpty()) {
-            append(" --test-data-path=${testDataPaths.joinToString(",")}")
-        }
+    /**
+     * Whether the linked Gradle project ships the dedicated `updateTestData` task. When `true`
+     * and [mode] is [TestDataManagerMode.UPDATE], the builder emits `updateTestData` with `-P`
+     * properties; otherwise it emits `manageTestDataGlobally` with `--option` CLI flags.
+     */
+    var updateTestDataIsAvailable: Boolean = false
 
-        testClassPattern?.let { append(" --test-class-pattern=$it") }
-        goldenOnly?.let { if (it) append(" --golden-only") }
-        incremental?.let { if (it) append(" --incremental") }
+    private val isUpdateTask: Boolean
+        get() = updateTestDataIsAvailable && mode == TestDataManagerMode.UPDATE
+
+    fun build(): String = buildString {
+        append(buildTaskPart())
+        appendOption(
+            cliKey = "test-data-path",
+            propKey = "testDataPath",
+            value = testDataPaths.takeIf { it.isNotEmpty() }?.joinToString(","),
+        )
+
+        appendOption(cliKey = "test-class-pattern", propKey = "testClassPattern", value = testClassPattern)
+        appendBooleanFlag(cliKey = "golden-only", propKey = "goldenOnly", value = goldenOnly)
+        appendBooleanFlag(cliKey = "incremental", propKey = "incremental", value = incremental)
         append(" --continue")
     }
 
+    private fun buildTaskPart(): String =
+        if (isUpdateTask) {
+            "updateTestData"
+        } else {
+            buildString {
+                append("manageTestDataGlobally")
+                mode?.let { append(" --mode=${it.cliValue}") }
+            }
+        }
+
+    private fun StringBuilder.appendOption(cliKey: String, propKey: String, value: String?) {
+        if (value == null) return
+        append(' ')
+        if (isUpdateTask) {
+            append("-P$UPDATE_OPTIONS_PREFIX.$propKey=$value")
+        } else {
+            append("--$cliKey=$value")
+        }
+    }
+
+    private fun StringBuilder.appendBooleanFlag(cliKey: String, propKey: String, value: Boolean?) {
+        if (value != true) return
+        append(' ')
+        if (isUpdateTask) {
+            append("-P$UPDATE_OPTIONS_PREFIX.$propKey=true")
+        } else {
+            append("--$cliKey")
+        }
+    }
+
     fun asTitle(): String = buildString {
-        when (mode) {
-            TestDataManagerMode.CHECK -> append("Check")
-            TestDataManagerMode.UPDATE -> append("Update")
-            null -> append("Manage")
+        when {
+            isUpdateTask || mode == TestDataManagerMode.UPDATE -> append("Update")
+            mode == TestDataManagerMode.CHECK -> append("Check")
+            else -> append("Manage")
         }
 
         append(" Test Data")
@@ -53,6 +108,9 @@ class TestDataManagerCommandBuilder {
     }
 }
 
-fun buildTestDataManagerCommand(configure: TestDataManagerCommandBuilder.() -> Unit = {}): String {
-    return TestDataManagerCommandBuilder().apply(configure).build()
-}
+fun buildTestDataManagerCommand(
+    updateTestDataIsAvailable: Boolean = false,
+    configure: TestDataManagerCommandBuilder.() -> Unit = {},
+): String = TestDataManagerCommandBuilder().apply {
+    this.updateTestDataIsAvailable = updateTestDataIsAvailable
+}.apply(configure).build()

--- a/test/org/jetbrains/kotlin/test/helper/test/data/manager/TestDataManagerCommandBuilderTest.kt
+++ b/test/org/jetbrains/kotlin/test/helper/test/data/manager/TestDataManagerCommandBuilderTest.kt
@@ -2,6 +2,7 @@ package org.jetbrains.kotlin.test.helper.test.data.manager
 
 import org.jetbrains.kotlin.test.helper.actions.test.data.manager.TestDataManagerCommandBuilder
 import org.jetbrains.kotlin.test.helper.actions.test.data.manager.TestDataManagerMode
+import org.jetbrains.kotlin.test.helper.actions.test.data.manager.buildTestDataManagerCommand
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -14,6 +15,12 @@ class TestDataManagerCommandBuilderTest {
         val builder = TestDataManagerCommandBuilder().apply(configure)
         assertEquals(expectedCommand, builder.build())
         assertEquals(expectedTitle, builder.asTitle())
+
+        // Cross-check that the public helper produces the same command.
+        assertEquals(
+            expectedCommand,
+            buildTestDataManagerCommand(builder.updateTestDataIsAvailable, configure),
+        )
     }
 
     @Test
@@ -208,4 +215,138 @@ class TestDataManagerCommandBuilderTest {
             goldenOnly = true
         }
     }
+
+    // region updateTestDataIsAvailable — switches to the dedicated `updateTestData` task
+
+    @Test
+    fun `updateTestDataIsAvailable without mode falls back to manageTestDataGlobally`() {
+        // The flag alone does not switch tasks — the dedicated `updateTestData` task only
+        // handles UPDATE mode, so without that mode we keep the global task.
+        assertBuilder(
+            expectedCommand = "manageTestDataGlobally --continue",
+            expectedTitle = "Manage Test Data",
+        ) {
+            updateTestDataIsAvailable = true
+        }
+    }
+
+    @Test
+    fun `updateTestDataIsAvailable with CHECK mode falls back to manageTestDataGlobally`() {
+        // `updateTestData` cannot run check mode; CHECK actions always go through the global task.
+        assertBuilder(
+            expectedCommand = "manageTestDataGlobally --mode=check --continue",
+            expectedTitle = "Check Test Data",
+        ) {
+            updateTestDataIsAvailable = true
+            mode = TestDataManagerMode.CHECK
+        }
+    }
+
+    @Test
+    fun `UPDATE mode with updateTestDataIsAvailable selects updateTestData`() {
+        assertBuilder(
+            expectedCommand = "updateTestData --continue",
+            expectedTitle = "Update Test Data",
+        ) {
+            updateTestDataIsAvailable = true
+            mode = TestDataManagerMode.UPDATE
+        }
+    }
+
+    @Test
+    fun `updateTestData with single path`() {
+        assertBuilder(
+            expectedCommand = "updateTestData -Porg.jetbrains.kotlin.testDataManager.options.testDataPath=path/to/data --continue",
+            expectedTitle = "Update Test Data: data",
+        ) {
+            updateTestDataIsAvailable = true
+            mode = TestDataManagerMode.UPDATE
+            testDataPaths = listOf("path/to/data")
+        }
+    }
+
+    @Test
+    fun `updateTestData with multiple paths`() {
+        assertBuilder(
+            expectedCommand = "updateTestData -Porg.jetbrains.kotlin.testDataManager.options.testDataPath=path/to/a.txt,other/b.kt --continue",
+            expectedTitle = "Update Test Data: a.txt, b.kt",
+        ) {
+            updateTestDataIsAvailable = true
+            mode = TestDataManagerMode.UPDATE
+            testDataPaths = listOf("path/to/a.txt", "other/b.kt")
+        }
+    }
+
+    @Test
+    fun `updateTestData with goldenOnly true`() {
+        assertBuilder(
+            expectedCommand = "updateTestData -Porg.jetbrains.kotlin.testDataManager.options.goldenOnly=true --continue",
+            expectedTitle = "Update Test Data (Golden Only)",
+        ) {
+            updateTestDataIsAvailable = true
+            mode = TestDataManagerMode.UPDATE
+            goldenOnly = true
+        }
+    }
+
+    @Test
+    fun `updateTestData with goldenOnly false omits the property`() {
+        assertBuilder(
+            expectedCommand = "updateTestData --continue",
+            expectedTitle = "Update Test Data",
+        ) {
+            updateTestDataIsAvailable = true
+            mode = TestDataManagerMode.UPDATE
+            goldenOnly = false
+        }
+    }
+
+    @Test
+    fun `updateTestData with incremental`() {
+        assertBuilder(
+            expectedCommand =
+                "updateTestData -Porg.jetbrains.kotlin.testDataManager.options.testDataPath=a/b.txt " +
+                    "-Porg.jetbrains.kotlin.testDataManager.options.incremental=true --continue",
+            expectedTitle = "Update Test Data (Incremental): b.txt",
+        ) {
+            updateTestDataIsAvailable = true
+            mode = TestDataManagerMode.UPDATE
+            incremental = true
+            testDataPaths = listOf("a/b.txt")
+        }
+    }
+
+    @Test
+    fun `updateTestData with test class pattern`() {
+        assertBuilder(
+            expectedCommand = "updateTestData -Porg.jetbrains.kotlin.testDataManager.options.testClassPattern=.*MyTest.* --continue",
+            expectedTitle = "Update Test Data",
+        ) {
+            updateTestDataIsAvailable = true
+            mode = TestDataManagerMode.UPDATE
+            testClassPattern = ".*MyTest.*"
+        }
+    }
+
+    @Test
+    fun `updateTestData with all parameters`() {
+        assertBuilder(
+            expectedCommand =
+                "updateTestData " +
+                    "-Porg.jetbrains.kotlin.testDataManager.options.testDataPath=path/one,path/two " +
+                    "-Porg.jetbrains.kotlin.testDataManager.options.testClassPattern=.*MyTest.* " +
+                    "-Porg.jetbrains.kotlin.testDataManager.options.goldenOnly=true " +
+                    "-Porg.jetbrains.kotlin.testDataManager.options.incremental=true --continue",
+            expectedTitle = "Update Test Data (Golden Only) (Incremental): one, two",
+        ) {
+            updateTestDataIsAvailable = true
+            mode = TestDataManagerMode.UPDATE
+            testDataPaths = listOf("path/one", "path/two")
+            testClassPattern = ".*MyTest.*"
+            goldenOnly = true
+            incremental = true
+        }
+    }
+
+    // endregion
 }


### PR DESCRIPTION
When the linked Gradle project ships the dedicated `updateTestData` task, the Update Test Data actions now run it with `-P` Gradle properties instead of `manageTestDataGlobally --mode=update` with CLI flags. This avoids the 1–2 minute Gradle reconfiguration that changing CLI options on `manageTestDataGlobally` triggers under configuration-cache. CHECK actions and projects without the new task keep the legacy command unchanged.