### PR TITLE
Navigation to `FirErrors` from tests

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -46,6 +46,9 @@
         <psi.referenceContributor implementation="org.jetbrains.kotlin.test.helper.reference.DirectiveReferenceContributor"
                                   language="kotlin"/>
 
+        <psi.referenceContributor implementation="org.jetbrains.kotlin.test.helper.reference.ReportedErrorReferenceContributor"
+                                  language="kotlin"/>
+
         <completion.contributor language="kotlin" implementationClass="org.jetbrains.kotlin.test.helper.completion.CommentDirectiveCompletionContributor"/>
 
         <executor implementation="org.jetbrains.kotlin.test.helper.executor.RunAndApplyDiffsExecutor"/>

--- a/src/org/jetbrains/kotlin/test/helper/reference/DirectiveReferenceContributor.kt
+++ b/src/org/jetbrains/kotlin/test/helper/reference/DirectiveReferenceContributor.kt
@@ -40,12 +40,17 @@ class DirectiveReferenceContributor : PsiReferenceContributor() {
                                 featuresRange.first + valueRange.first,
                                 featuresRange.first + valueRange.last + 1,
                             )
-                            val enumType: EnumClassProvider = if (name == "LANGUAGE") {
+                            val enumType: ClassProvider = if (name == "LANGUAGE") {
                                 ::getLanguageFeatureClasses
                             } else {
                                 { getEnumClassesByDirective(name, it) }
                             }
-                            val reference = EnumValueReference(element, valueTextRange, value, enumType)
+                            val reference = SingleMemberReference(
+                                element,
+                                valueTextRange,
+                                value,
+                                enumType
+                            )
                             refs.add(reference)
                         }
                     }

--- a/src/org/jetbrains/kotlin/test/helper/reference/DirectiveReferenceContributor.kt
+++ b/src/org/jetbrains/kotlin/test/helper/reference/DirectiveReferenceContributor.kt
@@ -35,21 +35,21 @@ class DirectiveReferenceContributor : PsiReferenceContributor() {
 
                         val (features, featuresRange) = match.groups[2] ?: return@let
                         regexValue.findAll(features).forEach {
-                            val (value, valueRange) = it.groups[1] ?: return@forEach
+                            val (memberShortName, valueRange) = it.groups[1] ?: return@forEach
                             val valueTextRange = TextRange(
                                 featuresRange.first + valueRange.first,
                                 featuresRange.first + valueRange.last + 1,
                             )
-                            val enumType: ClassProvider = if (name == "LANGUAGE") {
-                                ::getLanguageFeatureClasses
-                            } else {
-                                { getEnumClassesByDirective(name, it) }
+                            val classProvider: ClassProvider = when (name) {
+                                "LANGUAGE" -> ::getLanguageFeatureClasses
+                                "DIAGNOSTICS" -> ::getFirErrorClasses
+                                else -> { project -> getEnumClassesByDirective(name, project) }
                             }
                             val reference = SingleMemberReference(
                                 element,
                                 valueTextRange,
-                                value,
-                                enumType
+                                memberShortName,
+                                classProvider
                             )
                             refs.add(reference)
                         }

--- a/src/org/jetbrains/kotlin/test/helper/reference/ReportedErrorReferenceContributor.kt
+++ b/src/org/jetbrains/kotlin/test/helper/reference/ReportedErrorReferenceContributor.kt
@@ -1,0 +1,78 @@
+package org.jetbrains.kotlin.test.helper.reference
+
+import com.intellij.injected.editor.VirtualFileWindow
+import com.intellij.openapi.util.TextRange
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.psi.*
+import com.intellij.util.ProcessingContext
+import org.jetbrains.kotlin.test.helper.isTestDataFile
+
+/**
+ * [PsiReferenceContributor] that embeds references to `FirErrors` into the reported test data diagnostics.
+ *
+ * The contributor supports various cases:
+ * - Single diagnostics `<!TYPE_MISMATCH!>`
+ * - Multiple diagnostics on the same element `<!TYPE_MISMATCH, UNSUPPORTED_FEATURE!>`
+ * - Diagnostics with additional metadata `<!UNSUPPORTED_FEATURE("gotcha")!>`.
+ *   In such cases, the reference is embedded into the diagnostic name (`UNSUPPORTED_FEATURE`).
+ *
+ * ### Example:
+ * ```kotlin
+ * fun main() {
+ *   throw <!TYPE_MISMATCH!>"str"<!>
+ * //        ^^^^^^^^^^^^^
+ * //   Navigates to `FirErrors.TYPE_MISMATCH`
+ * }
+ * ```
+ */
+class ReportedErrorReferenceContributor : PsiReferenceContributor() {
+    private val groupRegex = Regex("<![A-Z].*?!>")
+    private val entriesRegex = Regex("(?<=<!|, )([A-Z_]+)(?=,|!>|\\()")
+
+    override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
+        registrar.registerReferenceProvider(
+            // To avoid working with PSI parse errors, the matcher is run on the PsiFile text
+            PlatformPatterns.psiElement(PsiFile::class.java),
+            object : PsiReferenceProvider() {
+                override fun getReferencesByElement(
+                    element: PsiElement,
+                    ctx: ProcessingContext,
+                ): Array<PsiReference> {
+                    element.containingFile
+                        ?.virtualFile
+                        ?.let { (it as? VirtualFileWindow)?.delegate ?: it }
+                        ?.takeIf { it.isTestDataFile(element.project) }
+                        ?: return PsiReference.EMPTY_ARRAY
+
+                    val text = element.text
+                    val refs = mutableListOf<PsiReference>()
+
+                    // Search for individual <!...!> groups
+                    groupRegex.findAll(text).forEach { groupMatch ->
+
+                        val (groupContent, groupMatchRange) = groupMatch.groups[0] ?: return@forEach
+                        val groupStartOffset = groupMatchRange.first
+
+                        // Search for diagnostic entries inside one group
+                        entriesRegex.findAll(groupContent).forEach { errorEntry ->
+                            val (errorContent, errorMatchRange) = errorEntry.groups[1] ?: return@forEach
+                            val startOffset = groupStartOffset + errorMatchRange.first
+                            val endOffset = groupStartOffset + errorMatchRange.last + 1
+                            val range = TextRange(startOffset, endOffset)
+                            refs.add(
+                                SingleMemberReference(
+                                    element,
+                                    range,
+                                    errorContent,
+                                    ::getFirErrorClasses
+                                )
+                            )
+                        }
+                    }
+
+                    return refs.toTypedArray()
+                }
+            },
+        )
+    }
+}

--- a/src/org/jetbrains/kotlin/test/helper/reference/SingleMemberReference.kt
+++ b/src/org/jetbrains/kotlin/test/helper/reference/SingleMemberReference.kt
@@ -1,0 +1,47 @@
+package org.jetbrains.kotlin.test.helper.reference
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementResolveResult
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiPolyVariantReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.ResolveResult
+
+typealias ClassProvider = (Project) -> List<PsiClass>
+
+/**
+ * A PSI reference for resolution to a single field member inside some class
+ *
+ * @param element The host of the reference
+ * @param range Reference text range inside [element]
+ * @property memberShortName Short name of the target member
+ * @property containingClassProvider Provider for the enclosing class of the target member
+ */
+class SingleMemberReference(
+    element: PsiElement,
+    range: TextRange,
+    private val memberShortName: String,
+    private val containingClassProvider: ClassProvider
+) : PsiReferenceBase<PsiElement>(element, range), PsiPolyVariantReference {
+
+    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
+        val project = myElement.project
+        val classes = containingClassProvider(project)
+
+        return classes.mapNotNull { clazz ->
+            clazz.fields
+                .filterIsInstance<PsiField>()
+                .firstOrNull { it.name == memberShortName }
+                ?.let { PsiElementResolveResult(it) }
+        }.toTypedArray()
+    }
+
+    override fun resolve(): PsiElement? {
+        return multiResolve(false).singleOrNull()?.element
+    }
+
+    override fun getVariants(): Array<Any> = emptyArray()
+}

--- a/src/org/jetbrains/kotlin/test/helper/reference/referenceUtils.kt
+++ b/src/org/jetbrains/kotlin/test/helper/reference/referenceUtils.kt
@@ -1,15 +1,8 @@
 package org.jetbrains.kotlin.test.helper.reference
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiElementResolveResult
-import com.intellij.psi.PsiEnumConstant
-import com.intellij.psi.PsiPolyVariantReference
-import com.intellij.psi.PsiReferenceBase
-import com.intellij.psi.ResolveResult
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.types.KaClassType
@@ -21,38 +14,7 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtDeclarationWithReturnType
 
-const val LANGUAGE_FEATURE_FQ_NAME = "org.jetbrains.kotlin.config.LanguageFeature"
-
-private val VALUE_DIRECTIVE_CLASS_ID =
-    ClassId.topLevel(FqName("org.jetbrains.kotlin.test.directives.model.ValueDirective"))
-
-typealias EnumClassProvider = (Project) -> List<PsiClass>
-
-class EnumValueReference(
-    element: PsiElement,
-    range: TextRange,
-    private val key: String,
-    private val enumType: EnumClassProvider
-) : PsiReferenceBase<PsiElement>(element, range), PsiPolyVariantReference {
-
-    override fun multiResolve(incompleteCode: Boolean): Array<ResolveResult> {
-        val project = myElement.project
-        val classes = enumType(project)
-
-        return classes.mapNotNull { clazz ->
-            clazz.fields
-                .filterIsInstance<PsiEnumConstant>()
-                .firstOrNull { it.name == key }
-                ?.let { PsiElementResolveResult(it) }
-        }.toTypedArray()
-    }
-
-    override fun resolve(): PsiElement? {
-        return multiResolve(false).singleOrNull()?.element
-    }
-
-    override fun getVariants(): Array<Any> = emptyArray()
-}
+private const val LANGUAGE_FEATURE_FQ_NAME = "org.jetbrains.kotlin.config.LanguageFeature"
 
 fun getLanguageFeatureClasses(project: Project): List<PsiClass> {
     val psiFacade = JavaPsiFacade.getInstance(project)
@@ -61,6 +23,9 @@ fun getLanguageFeatureClasses(project: Project): List<PsiClass> {
         psiFacade.findClasses(LANGUAGE_FEATURE_FQ_NAME, it).toList()
     }
 }
+
+private val VALUE_DIRECTIVE_CLASS_ID =
+    ClassId.topLevel(FqName("org.jetbrains.kotlin.test.directives.model.ValueDirective"))
 
 fun getEnumClassesByDirective(key: String, project: Project): List<KtLightClass> {
     return resolvePreferringProjectScope(project) {
@@ -77,5 +42,15 @@ fun getEnumClassesByDirective(key: String, project: Project): List<KtLightClass>
                 }
             }
         }
+    }
+}
+
+private const val FIR_ERRORS_FQ_NAME = "org.jetbrains.kotlin.fir.analysis.diagnostics.FirErrors"
+
+fun getFirErrorClasses(project: Project): List<PsiClass> {
+    val psiFacade = JavaPsiFacade.getInstance(project)
+
+    return resolvePreferringProjectScope(project) {
+        psiFacade.findClasses(FIR_ERRORS_FQ_NAME, it).toList()
     }
 }


### PR DESCRIPTION
Possible solution for https://github.com/JetBrains/kotlin-compiler-devkit/issues/72.

What's new:
-  Navigation to `FirErrors` from in-text reported diagnostics. Supports singles `<!TYPE_MISMATCH!>`, groups `<!TYPE_MISMATCH, UNSUPPORTED_FEATURE!>`, diagnostics with metadata `<!UNSUPPORTED_FEATURE("gotcha")!>`
- Navigation to `FirErrors` from diagnostics directives `// DIAGNOSTICS: +UNUSED_VARIABLE`

Please let me know if I've missed some additional important cases.

Toy demo:

https://github.com/user-attachments/assets/cb5d30ea-5cc6-4470-9557-d4cb40fda8be