### PR TITLE
Do not inject reported test diagnostics

### DIFF
--- a/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataMultiHostInjector.kt
+++ b/src/org/jetbrains/kotlin/test/helper/codeinsight/MultifileTestDataMultiHostInjector.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.kotlin.test.helper.codeinsight
 
+import com.intellij.lang.Language
 import com.intellij.lang.injection.MultiHostInjector
 import com.intellij.lang.injection.MultiHostRegistrar
 import com.intellij.openapi.fileTypes.PlainTextLanguage
@@ -17,6 +18,21 @@ import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataTextBlock
 class MultifileTestDataMultiHostInjector: MultiHostInjector {
     private val supportedElementTypes: List<Class<out PsiElement>> =
         listOf(MultifileTestDataFileContent::class.java, PsiComment::class.java, MultifileTestDataTextBlock::class.java)
+
+    /**
+     * Diagnostic markers (`<!DIAGNOSTIC!>` … `<!>`) are not valid code. They are excluded from the
+     * injected fragment so that the hints / resolution is calculated against the host
+     * test file instead of the injected editor.
+     *
+     * Otherwise, some features, e.g., underscore hints for `DIAGNOSTICS` references are shown incorrectly.
+     * That's because [org.jetbrains.kotlin.test.helper.reference.ReportedErrorReferenceContributor] calculates
+     * reference ranges based on the whole `.kt` test file, which contains all the inner files as well as preambles.
+     * If `<!DIAGNOSTIC!>` is injected as well, the text ranges of the reference for the highlighting
+     * are shifted to the right by the start offset of the injected fragment.
+     *
+     * This regex is used to keep `<!DIAGNOSTIC!>` … `<!>` from being injected.
+     */
+    private val diagnosticMarkerRegex = Regex("<![A-Z].*?!>|<!>")
 
     override fun getLanguagesToInject(
         registrar: MultiHostRegistrar,
@@ -37,9 +53,39 @@ class MultifileTestDataMultiHostInjector: MultiHostInjector {
             else -> null
         } ?: return
 
-        registrar.startInjecting(language)
-        registrar.addPlace(null, null, textBlock, TextRange(0, textBlock.textLength))
-        registrar.doneInjecting()
+        injectExcludingDiagnosticMarkers(registrar, textBlock, language)
+    }
+
+    /**
+     * Adds an injection place for every code segment between diagnostic markers, leaving the
+     * markers themselves as non-injected host text. See [diagnosticMarkerRegex].
+     */
+    private fun injectExcludingDiagnosticMarkers(
+        registrar: MultiHostRegistrar,
+        textBlock: MultifileTestDataTextBlock,
+        language: Language
+    ) {
+        val text = textBlock.text
+        val rangesToInject = mutableListOf<TextRange>()
+        var segmentStart = 0
+        for (marker in diagnosticMarkerRegex.findAll(text)) {
+            if (marker.range.first > segmentStart) {
+                rangesToInject.add(TextRange(segmentStart, marker.range.first))
+            }
+            segmentStart = marker.range.last + 1
+        }
+        if (segmentStart < text.length) {
+            rangesToInject.add(TextRange(segmentStart, text.length))
+        }
+
+        // If the whole file is just diagnostics, nothing should be injected
+        if (rangesToInject.isNotEmpty()) {
+            registrar.startInjecting(language)
+            for (place in rangesToInject) {
+                registrar.addPlace(null, null, textBlock, place)
+            }
+            registrar.doneInjecting()
+        }
     }
 
     private fun injectCommentsAsKotlin(

--- a/src/org/jetbrains/kotlin/test/helper/reference/ReportedErrorReferenceContributor.kt
+++ b/src/org/jetbrains/kotlin/test/helper/reference/ReportedErrorReferenceContributor.kt
@@ -6,6 +6,7 @@ import com.intellij.patterns.PlatformPatterns
 import com.intellij.psi.*
 import com.intellij.util.ProcessingContext
 import org.jetbrains.kotlin.test.helper.isTestDataFile
+import org.jetbrains.kotlin.test.helper.lang.MultifileTestDataTextFileImpl
 
 /**
  * [PsiReferenceContributor] that embeds references to `FirErrors` into the reported test data diagnostics.
@@ -31,8 +32,7 @@ class ReportedErrorReferenceContributor : PsiReferenceContributor() {
 
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
         registrar.registerReferenceProvider(
-            // To avoid working with PSI parse errors, the matcher is run on the PsiFile text
-            PlatformPatterns.psiElement(PsiFile::class.java),
+            PlatformPatterns.psiElement(MultifileTestDataTextFileImpl::class.java),
             object : PsiReferenceProvider() {
                 override fun getReferencesByElement(
                     element: PsiElement,


### PR DESCRIPTION
This one was a head-scratcher for sure. Fixes issues with reported diagnostic references highlighting being shown on the wrong line by not injecting `<!DIAGNOSTIC!>` … `<!>` at all. 
<img width="1161" height="264" alt="image" src="https://github.com/user-attachments/assets/27217cc6-9ddf-452e-913d-5fa38b171df2" />


Diagnostic markers (`<!DIAGNOSTIC!>` … `<!>`) are not valid code. They are excluded from the injected fragment so that the hints / resolution is calculated against the host test file instead of the injected editor. Otherwise, some features, e.g., underscore hints for `DIAGNOSTICS` references are shown incorrectly. That's because `ReportedErrorReferenceContributor` calculates reference ranges based on the whole `.kt` test file, which contains all the inner files as well as preambles. If `<!DIAGNOSTIC!>` is injected as well, the text ranges of the reference for the highlighting are shifted to the right by the start offset of the injected fragment.

As a bonus, if the diagnostic is reported in the middle of some real code reference, the reference is still resolved. That's because now reported diagnostics do not interfere with the injected Kotlin resolution. E.g., with `class AA` and diagnostic `A<!DIAGNOSTIC!>A()`, `AA` constructor reference would still be resolved.

Demo:

https://github.com/user-attachments/assets/33b3c86f-f14e-436f-8bf2-dbd3540a192a