### PR TITLE
Hide the default text editor

### DIFF
--- a/src/org/jetbrains/kotlin/test/helper/KotlinTestDataFileEditorProvider.kt
+++ b/src/org/jetbrains/kotlin/test/helper/KotlinTestDataFileEditorProvider.kt
@@ -22,7 +22,7 @@ class KotlinTestDataFileEditorProvider: AsyncFileEditorProvider, DumbAware {
 
     override fun getEditorTypeId(): String = "Kotlin TestData Editor"
 
-    override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.PLACE_BEFORE_DEFAULT_EDITOR
+    override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.HIDE_DEFAULT_EDITOR
 
     override fun createEditorAsync(project: Project, file: VirtualFile): AsyncFileEditorProvider.Builder {
         return object: AsyncFileEditorProvider.Builder() {


### PR DESCRIPTION
Previously, there were two editors for the test data: `Text` (regular one) and `Test Data` (custom plugin editor with split view, tests, etc.).
These editors only shared the same file, but it was the only common thing between them.
Each of these two editors had its own caret, view, etc.
Generally, this shouldn't be a problem.
However, these two editors were still clashing during some regular IDE workflows.

For example, one could observe this clash when using `Search Everywhere` action (`Shift + CMD + F`) on test data entries.
IDE showed the list of found entries among the test files, but the navigation took users to the first line of the containing file instead of the actual entry position.
That's because the caret was moved in the `Test Data` editor while the navigation opened the default `Text` editor.
`Test Data` editor had higher priority for the caret shift as `KotlinTestDataFileEditorProvider.getPolicy` was set to `PLACE_BEFORE_DEFAULT_EDITOR`.
But the navigation preferred the `Text` editor as it's the canonical one.

Completely hide the default editor by changing the policy to `FileEditorPolicy.HIDE_DEFAULT_EDITOR`.
There is no point in keeping it as the default editor doesn't have any real advantages over the `Test Data` editor.
But keeping them in parallel could lead to various editing anomalies.

Issue: https://github.com/JetBrains/kotlin-compiler-devkit/issues/145

Demo: 

https://github.com/user-attachments/assets/ff1e4678-0ea2-4fa2-a356-847faf81d015



